### PR TITLE
missing includedirs from roscpp cause compile errors.

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -12,7 +12,7 @@ catkin_package(DEPENDS diagnostic_msgs pluginlib roscpp rospy xmlrpcpp
 find_package(Boost REQUIRED COMPONENTS system regex)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
-include_directories(include)
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   src/status_item.cpp

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -8,7 +8,7 @@ catkin_package(DEPENDS diagnostic_msgs roscpp std_msgs
                INCLUDE_DIRS include
 )
 
-include_directories(include)
+include_directories(include ${catkin_INCLUDE_DIRS})
 add_executable(example src/example.cpp)
 target_link_libraries(example ${catkin_LIBRARIES})
 


### PR DESCRIPTION
diagnostic_aggregator/include/diagnostic_aggregator/status_item.h:45:21: fatal error: ros/ros.h: No such file or directory

diagnostics/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.h:42:29: fatal error: ros/node_handle.h: No such file or directory
compilation terminated.

Note that what worries me is why this ever worked for anyone else. What am I missing?
