### PR TITLE
Added rostest to build requirements for test_diagnostic_aggregator

### DIFF
--- a/test_diagnostic_aggregator/package.xml
+++ b/test_diagnostic_aggregator/package.xml
@@ -20,6 +20,7 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>rostest</build_depend>
 
   <run_depend>diagnostic_aggregator</run_depend>
   <run_depend>diagnostic_msgs</run_depend>


### PR DESCRIPTION
Not sure how this one slipped through, but rostest is find_package()'d in the CMakeLists.txt.
