### PR TITLE
catkin libraries are linked for test_diagnostic_aggregator target

### DIFF
--- a/test_diagnostic_aggregator/CMakeLists.txt
+++ b/test_diagnostic_aggregator/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(include)
 add_library(test_diagnostic_aggregator
   src/match_no_analyze_analyzer.cpp
   src/fail_init_analyzer.cpp)
+target_link_libraries(test_diagnostic_aggregator ${catkin_LIBRARIES})
 add_dependencies(test_diagnostic_aggregator diagnostic_msgs_gencpp)
 
 add_rostest(test/launch/test_match_no_analyze_analyzer_load.launch)


### PR DESCRIPTION
Otherwise there are link errors for class_loader on Mac OS X.

```
Undefined symbols for architecture x86_64:
"class_loader::class_loader_private::AbstractMetaObjectBase:: addOwningClassLoader(class_loader::ClassLoader*)", referenced from:
  void class_loader::class_loader_private::registerPlugin<test_diagnostic_aggregator::MatchNoAnalyzeAnalyzer, diagnostic_aggregator::Analyzer>(std::string const&, std::string const&) in match_no_analyze_analyzer.cpp.o
```
