### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -31,18 +31,20 @@ target_link_libraries(aggregator_node ${catkin_LIBRARIES}
                                       ${PROJECT_NAME}
 )
 
-add_rostest(test/launch/test_agg.launch)
+if(CATKIN_ENABLE_TESTING)
+  add_rostest(test/launch/test_agg.launch)
 
-# Analyzer loader allows other users to test that Analyzers load
-catkin_add_gtest(analyzer_loader test/analyzer_loader.cpp)
-target_link_libraries(analyzer_loader diagnostic_aggregator)
-set_target_properties(analyzer_loader PROPERTIES EXCLUDE_FROM_ALL FALSE)
+  # Analyzer loader allows other users to test that Analyzers load
+  catkin_add_gtest(analyzer_loader test/analyzer_loader.cpp)
+  target_link_libraries(analyzer_loader diagnostic_aggregator)
+  set_target_properties(analyzer_loader PROPERTIES EXCLUDE_FROM_ALL FALSE)
 
 
-# Test Analyzer loader
-add_rostest(test/launch/test_loader.launch)
-add_rostest(test/launch/test_expected_stale.launch)
-add_rostest(test/launch/test_multiple_match.launch)
+  # Test Analyzer loader
+  add_rostest(test/launch/test_loader.launch)
+  add_rostest(test/launch/test_expected_stale.launch)
+  add_rostest(test/launch/test_multiple_match.launch)
+endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/diagnostic_aggregator/package.xml
+++ b/diagnostic_aggregator/package.xml
@@ -12,7 +12,7 @@
   <url type="website">http://www.ros.org/wiki/diagnostic_aggregator</url>
 <!-- <url type="bugtracker"></url> -->
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>pluginlib</build_depend>

--- a/diagnostic_analysis/CMakeLists.txt
+++ b/diagnostic_analysis/CMakeLists.txt
@@ -6,4 +6,6 @@ find_package(catkin REQUIRED diagnostic_msgs rosbag roslib rostest)
 
 catkin_package(DEPENDS diagnostic_msgs rosbag roslib)
 
-catkin_add_nosetests(test/bag_csv_test.py)
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test/bag_csv_test.py)
+endif()

--- a/diagnostic_analysis/package.xml
+++ b/diagnostic_analysis/package.xml
@@ -16,7 +16,7 @@
   <author>Eric Berger</author>
   <author>Kevin Watts</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>rosbag</build_depend>

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -12,8 +12,10 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_executable(example src/example.cpp)
 target_link_libraries(example ${catkin_LIBRARIES})
 
-catkin_add_gtest(diagnostic_updater_test test/diagnostic_updater_test.cpp)
-add_rostest(test/diagnostic_updater_test.xml)
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(diagnostic_updater_test test/diagnostic_updater_test.cpp)
+  add_rostest(test/diagnostic_updater_test.xml)
+endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/diagnostic_updater/package.xml
+++ b/diagnostic_updater/package.xml
@@ -14,7 +14,7 @@
   <author>Jeremy Leibs</author>
   <author>Blaise Gassend</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>roscpp</build_depend>


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
