### PR TITLE
Remove stray architechture_independent flags

### DIFF
--- a/diagnostic_aggregator/package.xml
+++ b/diagnostic_aggregator/package.xml
@@ -36,6 +36,5 @@
   <export>
     <cpp lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib -ldiagnostic_aggregator `rosboost-cfg --lflags regex`" cflags="-I${prefix}/include `rosboost-cfg --cflags`"/>
     <diagnostic_aggregator plugin="${prefix}/analyzer_plugins.xml"/>
-    <architecture_independent/>
   </export>
 </package>

--- a/self_test/package.xml
+++ b/self_test/package.xml
@@ -28,8 +28,4 @@
   <!-- <test_depend>roscpp</test_depend> -->
   <!-- <test_depend>diagnostic_updater</test_depend> -->
   <!-- <test_depend>diagnostic_msgs</test_depend> -->
-
-  <export>
-    <architecture_independent/>
-  </export>
 </package>


### PR DESCRIPTION
This flag should be used for package which do not contain architecture-specific files. Compiled binaries are such a file, and these packages contain them.

See:
- http://www.ros.org/reps/rep-0127.html#architecture-independent
- https://github.com/ros-infrastructure/bloom/pull/270
