### PR TITLE
Add dependency on message generation

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${PROJECT_NAME}
 target_link_libraries(diagnostic_aggregator ${Boost_LIBRARIES}
                                             ${catkin_LIBRARIES}
 )
+add_dependencies(${PROJECT_NAME} diagnostic_msgs_generate_messages_cpp)
 
 # Aggregator node 
 add_executable(aggregator_node src/aggregator_node.cpp)


### PR DESCRIPTION
Without this, sometimes the diagnostic aggregator is built before the diagnostic_msgs messages are generated. This is only an issue when using common_msgs from source, so nobody noticed until now.
