### PR TITLE
Adds a libsensors based sensors_monitor node

### DIFF
--- a/diagnostic_common_diagnostics/CMakeLists.txt
+++ b/diagnostic_common_diagnostics/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(diagnostic_common_diagnostics)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin)
+find_package(catkin REQUIRED COMPONENTS roscpp diagnostic_updater)
 
 catkin_python_setup()
 
@@ -10,9 +10,21 @@ catkin_package()
 
 catkin_python_setup()
 
+
+include_directories(include ${catkin_INCLUDE_DIRS})
+add_executable(libsensors_monitor src/libsensors_monitor.cpp src/libsensors_chip.cpp)
+target_link_libraries(libsensors_monitor sensors ${catkin_LIBRARIES})
+
+
 install(PROGRAMS
   src/diagnostic_common_diagnostics/hd_monitor.py
   src/diagnostic_common_diagnostics/ntp_monitor.py
   src/diagnostic_common_diagnostics/sensors_monitor.py
   src/diagnostic_common_diagnostics/tf_monitor.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(TARGETS libsensors_monitor
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/diagnostic_common_diagnostics/include/diagnostic_common_diagnostics/libsensors_chip.h
+++ b/diagnostic_common_diagnostics/include/diagnostic_common_diagnostics/libsensors_chip.h
@@ -1,0 +1,112 @@
+#ifndef SENSOR_CHIP_H_
+#define SENSOR_CHIP_H_
+
+#include <stdlib.h>
+#include <sensors/sensors.h>
+#include <vector>
+#include <boost/shared_ptr.hpp>
+
+#include <diagnostic_updater/diagnostic_updater.h>
+
+class SensorChipSubFeature;
+class SensorChipFeature;
+class SensorChip;
+
+typedef boost::shared_ptr<SensorChip> SensorChipPtr;
+typedef boost::shared_ptr<SensorChipFeature> SensorChipFeaturePtr;
+typedef boost::shared_ptr<SensorChipSubFeature> SensorChipSubFeaturePtr;
+
+
+/**
+ * Represents a libsensors sensor chip
+ */
+class SensorChip{
+private:
+  std::string name_;
+  sensors_chip_name const *internal_name_;
+  void enumerate_features();
+public:
+  SensorChip(sensors_chip_name const *chip_name);
+  std::string getName(){return name_;}
+  std::vector<SensorChipFeaturePtr> features_;
+
+  friend class SensorChipFeature;
+  friend class SensorChipSubFeature;
+};
+
+
+/**
+ * Abstract base class for a libsensors sensor chip feature
+ */
+class SensorChipFeature {
+private:
+  std::string name_;
+  std::string label_;
+  std::string sensor_name_;
+  SensorChip& chip_;
+  sensors_feature const *feature_;
+  void enumerate_subfeatures();
+public:
+  std::vector<SensorChipSubFeaturePtr> sub_features_;
+  SensorChipFeature(SensorChip& chip, sensors_feature const *feature);
+  SensorChipSubFeaturePtr getSubFeatureByType(sensors_subfeature_type type);
+
+  std::string getName(){return name_;};
+  std::string getLabel(){return label_;};
+  virtual std::string getSensorName(){return sensor_name_;};
+  virtual std::string getSensorLabel(){return getLabel();};
+  sensors_feature_type getType(){return feature_->type;};
+  std::string getChipName(){return chip_.getName();};
+
+  /**
+   * Build a diagnostic status message that represents the current status of the
+   * sensor chip feature
+   */
+  virtual void buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat) = 0;
+
+  friend class SensorChipSubFeature;
+};
+
+
+/**
+ * Represents a libsensors sensor chip sub feature
+ */
+class SensorChipSubFeature {
+private:
+  std::string name_;
+  SensorChipFeature& feature_;
+  sensors_subfeature const *subfeature_;
+public:
+  SensorChipSubFeature(SensorChipFeature& feature, sensors_subfeature const *subfeature);
+  std::string getName();
+  sensors_subfeature_type getType();
+  double getValue();
+};
+
+
+
+class FanSensor : public SensorChipFeature{
+ public:
+  FanSensor(SensorChip& chip, sensors_feature const *feature);
+  virtual void buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat);
+};
+
+
+class TempSensor : public SensorChipFeature{
+ public:
+  TempSensor(SensorChip& chip, sensors_feature const *feature);
+  virtual void buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat);
+};
+
+
+/**
+ * Default case for presenting sensor feature status
+ */
+class OtherSensor : public SensorChipFeature{
+ public:
+  OtherSensor(SensorChip& chip, sensors_feature const *feature);
+  virtual void buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat);
+};
+
+
+#endif

--- a/diagnostic_common_diagnostics/package.xml
+++ b/diagnostic_common_diagnostics/package.xml
@@ -14,11 +14,16 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>rospy</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>diagnostic_updater</build_depend>
+  <build_depend>libsensors4-dev</build_depend>
 
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>hddtemp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>libsensors4-dev</run_depend>
 
   <!-- <test_depend>diagnostic_updater</test_depend> -->
   <!-- <test_depend>rospy</test_depend> -->

--- a/diagnostic_common_diagnostics/src/libsensors_chip.cpp
+++ b/diagnostic_common_diagnostics/src/libsensors_chip.cpp
@@ -1,0 +1,147 @@
+#include <stdlib.h>
+#include <ros/ros.h>
+#include <boost/foreach.hpp>
+#include <diagnostic_common_diagnostics/libsensors_chip.h>
+
+#define NAME_BUFFER_SIZE 50
+
+SensorChip::SensorChip(sensors_chip_name const *chip_name):internal_name_(chip_name){
+  char name_buffer[NAME_BUFFER_SIZE];
+  sensors_snprintf_chip_name(name_buffer, NAME_BUFFER_SIZE, internal_name_);
+  name_ = name_buffer;
+
+  ROS_INFO("Found Sensor: %s", getName().c_str());
+  enumerate_features();
+}
+void SensorChip::enumerate_features(){
+  features_.clear();
+
+  sensors_feature const *feature;
+  int number = 0;
+
+  while ((feature = sensors_get_features(internal_name_, &number)) != NULL) {
+    sensors_feature_type type = feature->type;
+    switch(type){
+    case SENSORS_FEATURE_FAN:
+      features_.push_back(SensorChipFeaturePtr(new FanSensor(*this, feature)));
+      break;
+    case SENSORS_FEATURE_TEMP:
+      features_.push_back(SensorChipFeaturePtr(new TempSensor(*this, feature)));
+      break;
+    default:
+      features_.push_back(SensorChipFeaturePtr(new OtherSensor(*this, feature)));
+      break;
+    }
+  }
+}
+
+
+
+SensorChipFeature::SensorChipFeature(SensorChip& chip, sensors_feature const *feature):chip_(chip), feature_(feature){
+  name_ = feature_->name;
+  char* label_c_str = sensors_get_label(chip_.internal_name_, feature_);
+  label_ = label_c_str;
+  free(label_c_str);
+  sensor_name_ = getChipName()+"/"+getName();
+
+
+  ROS_INFO("\tFound Feature: %s(%s)[%d]", getLabel().c_str(), getName().c_str(), feature_->type);
+
+  enumerate_subfeatures();
+}
+void SensorChipFeature::enumerate_subfeatures(){
+  sensors_subfeature const *subfeature;
+  int number = 0;
+
+  while ((subfeature = sensors_get_all_subfeatures(chip_.internal_name_, feature_, &number)) != NULL) {
+    sub_features_.push_back(SensorChipSubFeaturePtr(new SensorChipSubFeature(*this, subfeature)));
+  }
+}
+SensorChipSubFeaturePtr SensorChipFeature::getSubFeatureByType(sensors_subfeature_type type){
+  BOOST_FOREACH(SensorChipSubFeaturePtr subfeature, sub_features_){
+    if(subfeature->getType()==type)
+      return subfeature;
+  }
+  return SensorChipSubFeaturePtr();
+}
+
+
+
+
+SensorChipSubFeature::SensorChipSubFeature(SensorChipFeature& feature, sensors_subfeature const *subfeature):feature_(feature), subfeature_(subfeature){
+  name_ = subfeature_->name;
+
+  ROS_INFO("\t\tFound Sub-Feature: %s[%d] = %f", getName().c_str(), subfeature_->type, getValue());
+}
+std::string SensorChipSubFeature::getName(){
+  return name_;
+}
+double SensorChipSubFeature::getValue(){
+  double value;
+  sensors_get_value(feature_.chip_.internal_name_, subfeature_->number, &value);
+  return value;
+}
+sensors_subfeature_type SensorChipSubFeature::getType(){
+  return subfeature_->type;
+}
+
+
+
+
+
+
+FanSensor::FanSensor(SensorChip& chip, sensors_feature const *feature) : SensorChipFeature(chip, feature){}
+void FanSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat){
+  SensorChipSubFeaturePtr speed = getSubFeatureByType(SENSORS_SUBFEATURE_FAN_INPUT);
+  if(speed){
+    double speed_val = speed->getValue();
+    if(speed_val==0)
+      stat.summary(diagnostic_msgs::DiagnosticStatus::WARN, "Fan stalled or not connected");
+    else
+      stat.summaryf(diagnostic_msgs::DiagnosticStatus::OK, "Fan OK (%.2f RPM)", speed_val);
+    stat.add("Fan Speed (RPM)", speed_val);
+  }
+  else
+    stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "No Fan Input!!!");
+}
+
+
+
+
+TempSensor::TempSensor(SensorChip& chip, sensors_feature const *feature) : SensorChipFeature(chip, feature){}
+void TempSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat){
+  SensorChipSubFeaturePtr temp = getSubFeatureByType(SENSORS_SUBFEATURE_TEMP_INPUT);
+  SensorChipSubFeaturePtr max_temp = getSubFeatureByType(SENSORS_SUBFEATURE_TEMP_MAX);
+  SensorChipSubFeaturePtr temp_crit = getSubFeatureByType(SENSORS_SUBFEATURE_TEMP_CRIT);
+  SensorChipSubFeaturePtr temp_crit_alarm = getSubFeatureByType(SENSORS_SUBFEATURE_TEMP_CRIT_ALARM);
+  if(temp){
+    double temp_val = temp->getValue();
+    stat.add("Temperature (\xB0""C)", temp_val);
+
+    if(max_temp && max_temp->getValue()!=0)
+      stat.add("Max Temperature (\xB0""C)", max_temp->getValue());
+    if(temp_crit && temp_crit->getValue()!=0)
+      stat.add("Temperature Critical (\xB0""C)", temp_crit->getValue());
+
+    if(temp_crit_alarm && temp_crit_alarm->getValue()!=0)
+      stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN, "Critical Temp Alarm (%.2f\xB0""C)", temp_val);
+    else if(temp_crit && temp_crit->getValue()!=0 && temp_val > temp_crit->getValue())
+      stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN, "Critical Temp Alarm (%.2f\xB0""C)", temp_val);
+    else if(max_temp && max_temp->getValue()!=0 && temp_val > max_temp->getValue())
+      stat.summaryf(diagnostic_msgs::DiagnosticStatus::WARN, "Max Temp Alarm (%.2f\xB0""C)", temp_val);
+    else
+      stat.summaryf(diagnostic_msgs::DiagnosticStatus::OK, "Temp OK (%.2f\xB0""C)", temp_val);
+  }
+  else
+    stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "NO TEMP Input!!!");
+}
+
+
+
+OtherSensor::OtherSensor(SensorChip& chip, sensors_feature const *feature) : SensorChipFeature(chip, feature){}
+void OtherSensor::buildStatus(diagnostic_updater::DiagnosticStatusWrapper &stat){
+  stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Unkown sensor type");
+  BOOST_FOREACH(SensorChipSubFeaturePtr subfeature, sub_features_){
+    stat.add(subfeature->getName(), subfeature->getValue());
+  }
+}

--- a/diagnostic_common_diagnostics/src/libsensors_monitor.cpp
+++ b/diagnostic_common_diagnostics/src/libsensors_monitor.cpp
@@ -1,0 +1,78 @@
+#include <sensors/sensors.h>
+#include <string>
+#include <vector>
+#include <boost/foreach.hpp>
+#include <boost/algorithm/string/replace.hpp>
+
+#include <ros/ros.h>
+#include <diagnostic_common_diagnostics/libsensors_chip.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+
+// All of the enumerated sensor chips
+std::vector<SensorChipPtr> sensor_chips_;
+// Enumerate all of the sensor chips that exist on the system
+void enumerate_sensors(){
+  sensor_chips_.clear();
+
+  sensors_chip_name const *chip_name;
+  int number = 0;
+  while ((chip_name = sensors_get_detected_chips(NULL, &number)) != NULL){
+    sensor_chips_.push_back(SensorChipPtr(new SensorChip(chip_name)));
+  }
+}
+
+int main(int argc, char** argv){
+  // Get the hostname of the computer
+  char hostname_buf[1024];
+  int gethostname_result = gethostname(hostname_buf, sizeof(hostname_buf));
+  std::string hostname;
+  if(gethostname_result == 0) {
+    hostname = hostname_buf;
+    ROS_INFO_STREAM("Got system hostname: " << hostname);
+  }
+  else {
+    ROS_WARN("Could not get system hostname: %s", strerror(errno));
+  }
+
+  if(!hostname.empty()) {
+    std::string hostname_clean = boost::replace_all_copy(hostname, "-", "_");
+    ros::init(argc, argv, "sensor_monitor_"+hostname_clean);
+  }
+  else {
+    ros::init(argc, argv, "sensor_monitor");
+  }
+
+
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh;
+  diagnostic_updater::Updater updater(nh, pnh);
+  if(!hostname.empty()) {
+    updater.setHardwareID(hostname);
+  }
+  else {
+    updater.setHardwareID("none");
+  }
+
+  // Reset the libsensors library
+  sensors_cleanup();
+  sensors_init(NULL);
+
+  enumerate_sensors();
+
+  // Add each sensor to the diagnostic updater
+  BOOST_FOREACH(SensorChipPtr sensor_chip, sensor_chips_){
+    BOOST_FOREACH(SensorChipFeaturePtr sensor, sensor_chip->features_){
+      updater.add(sensor->getSensorName(), boost::bind(&SensorChipFeature::buildStatus, sensor, _1));
+    }
+  }
+
+
+  while(ros::ok()){
+    updater.update();
+    ros::spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+
+  sensors_cleanup();
+}
+


### PR DESCRIPTION
Right now there is only explicit support for Fans and Temperature sensors as the systems I have access to only support those.
However, all other sensors will show up with all of their information there is just no sensor specific summary, units or warning/error support.

Related to #33
