### PR TITLE
Remove stray architecture_independent export

### DIFF
--- a/diagnostic_common_diagnostics/package.xml
+++ b/diagnostic_common_diagnostics/package.xml
@@ -28,8 +28,4 @@
   <!-- <test_depend>diagnostic_updater</test_depend> -->
   <!-- <test_depend>rospy</test_depend> -->
   <!-- <test_depend>tf</test_depend> -->
-
-  <export>
-    <architecture_independent/>
-  </export>
 </package>


### PR DESCRIPTION
This should have been removed with https://github.com/ros/diagnostics/commit/3c1da654a1a2e0d26d2c1e96b047220f13e52c57

Example build break: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-diagnostic-common-diagnostics_binaryrpm_heisenbug_i386/44/console