### PR TITLE
diagnostic_aggregator: Add functionality for dynamically adding, deleting and listing analyzers

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.h
@@ -48,6 +48,9 @@
 #include <diagnostic_msgs/DiagnosticArray.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <diagnostic_msgs/KeyValue.h>
+#include <diagnostic_msgs/AddDiagnostics.h>
+#include <diagnostic_msgs/RemoveDiagnostics.h>
+#include <diagnostic_msgs/ListDiagnostics.h>
 #include "XmlRpcValue.h"
 #include "diagnostic_aggregator/analyzer.h"
 #include "diagnostic_aggregator/analyzer_group.h"
@@ -125,6 +128,9 @@ public:
 
 private:
   ros::NodeHandle n_;
+  ros::ServiceServer add_srv_; /**< AddDiagnostics, /diagnostics_agg/add_diagnostics */
+  ros::ServiceServer rem_srv_; /**< RemoveDiagnostics, /diagnostics_agg/remove_diagnostics */
+  ros::ServiceServer list_srv_; /**< ListDiagnostics, /diagnostics_agg/list_diagnostics */
   ros::Subscriber diag_sub_; /**< DiagnosticArray, /diagnostics */
   ros::Publisher agg_pub_;  /**< DiagnosticArray, /diagnostics_agg */
   ros::Publisher toplevel_state_pub_;  /**< DiagnosticStatus, /diagnostics_toplevel_state */
@@ -134,6 +140,15 @@ private:
    *\brief Callback for incoming "/diagnostics"
    */
   void diagCallback(const diagnostic_msgs::DiagnosticArray::ConstPtr& diag_msg);
+
+  bool addDiagnostics(diagnostic_msgs::AddDiagnostics::Request &req,
+		      diagnostic_msgs::AddDiagnostics::Response &res);
+  
+  bool removeDiagnostics(diagnostic_msgs::RemoveDiagnostics::Request &req,
+			 diagnostic_msgs::RemoveDiagnostics::Response &res);
+  
+  bool listDiagnostics(diagnostic_msgs::ListDiagnostics::Request &req,
+		       diagnostic_msgs::ListDiagnostics::Response &res);
 
   AnalyzerGroup* analyzer_group_;
 

--- a/diagnostic_aggregator/include/diagnostic_aggregator/analyzer.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/analyzer.h
@@ -130,10 +130,30 @@ public:
    */
   virtual std::vector<boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> > report() = 0;
 
+  /**!
+   *\brief Used by Analyzers which can contain other analyzers to recursively
+   * delete those analyzers whose paths contain given strings. Returns false by
+   * default for all other types.
+   */
+  virtual bool deleteAnalyzers(const std::string namespc) { return false; }
+  
   /*!
    *\brief Returns full prefix of analyzer. (ex: '/Robot/Sensors')
    */
   virtual std::string getPath() const = 0;
+
+  /**!
+   *\brief Return a vector containing the path of this analyzer if it is one
+   * which does not have sub-analyzers, or if it has sub-analyzers, recursively
+   * return the paths of its analyzers
+   */
+  virtual std::vector<std::string> listAnalyzers() const 
+  {
+    std::string path = getPath();
+    std::vector<std::string> path_vec = std::vector<std::string>();
+    path_vec.push_back(path);
+    return path_vec;
+  }
   
   /*!
    *\brief Returns nice name for display. (ex: 'Sensors')

--- a/diagnostic_aggregator/include/diagnostic_aggregator/analyzer_group.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/analyzer_group.h
@@ -42,6 +42,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <algorithm>
 #include <ros/ros.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <diagnostic_msgs/KeyValue.h>
@@ -119,6 +120,31 @@ public:
    * The parameters in its namespace determine the sub-analyzers.
    */
   virtual bool init(const std::string base_path, const ros::NodeHandle &n);
+
+  /*!
+   *\brief Initialized with base path and user-specified namespace rather than
+   * a nodehandle-specified one.
+   * 
+   * The parameters in its namespace determine the sub-analyzers.
+   */
+  virtual bool init(const std::string base_path, const std::string namespc);
+
+  /**!
+   *\brief Add an analyzer to this analyzerGroup
+   */
+  virtual bool addAnalyzer(boost::shared_ptr<Analyzer>& analyzer);
+
+  /**!
+   *\brief Recursively delete all analyzers from this analyzer group whose
+   * path is in the given namespace
+   */
+  virtual bool deleteAnalyzers(const std::string namespc);
+
+  /**!
+   *\brief Get the path for this analyzer and the paths of all analyzers that
+   * it contains.
+   */
+  virtual std::vector<std::string> listAnalyzers() const;
 
   /*!
    *\brief Match returns true if any sub-analyzers match an item

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
@@ -216,9 +216,7 @@ public:
     
     return processed;
   }
-  
 
-  
   /*!
    *\brief Match function isn't implemented by GenericAnalyzerBase
    */

--- a/diagnostic_aggregator/scripts/modify_diagnostics
+++ b/diagnostic_aggregator/scripts/modify_diagnostics
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+NAME='modify_diagnostics'
+
+import sys
+import optparse
+import roslib; roslib.load_manifest('rosparam')
+import rosparam
+import rospy
+
+from diagnostic_msgs.srv import AddDiagnostics, RemoveDiagnostics, ListDiagnostics
+
+def do_add():
+    usage = """Usage: %prog add [options] analyzer_yaml namespace
+
+    analyzer_yaml contains the definitions for analyzers to be added to the
+                  aggregator
+    
+    namespace     string defining the namespace which the parameters will be
+                  loaded into for reading by the aggregator."""
+    
+    parser = optparse.OptionParser(usage=usage, prog=NAME)
+    parser.add_option('-t', '--timeout', action='store', type='float', dest='timeout', default=None, help='time in seconds to wait for the diagnostic_agg service to come up before timing out. Default waits indefinitely')
+    options, args = parser.parse_args(myargv[2:])
+
+    if len(args) == 0:
+        parser.error('Invalid arguments. You must specify a yaml file to load from and a namespace to load into')
+    elif len(args) == 1:
+        parser.error('Invalid arguments. You must specify a namespace into which to load parameters')
+    elif len(args) > 2:
+        parser.error('Too many arguments')
+        
+    paramlist = rosparam.load_file(args[0])
+    namespace = args[1]
+    for params, ns in paramlist:
+        rosparam.upload_params(namespace + '/' + ns, params)
+        
+    try:
+        rospy.wait_for_service('/diagnostics_agg/add_diagnostics', timeout=options.timeout)
+        add_diagnostics = rospy.ServiceProxy('/diagnostics_agg/add_diagnostics', AddDiagnostics)
+        resp = add_diagnostics(namespc=namespace)
+        if resp.success:
+            rospy.loginfo('Successfully added analyzers to diagnostics')
+        else:
+            rospy.loginfo('Did not add any analyzers to diagnostics')
+    except rospy.ROSException:
+        rospy.logerr('Modify diagnostics add timed out while waiting for diagnostics_agg service')
+
+def do_delete():
+    usage = """Usage: %prog delete namespace
+    
+    namespace string defining the namespace to delete in the aggregator,
+              e.g. /Core/Navigation will delete all aggregators which
+              have a name beginning with that path."""
+    
+    parser = optparse.OptionParser(usage=usage, prog=NAME)
+    parser.add_option('-t', '--timeout', action='store', type='float', dest='timeout', default=None, help='time in seconds to wait for the diagnostic_agg service to come up before timing out. Default waits indefinitely')
+    
+    options, args = parser.parse_args(myargv[2:])
+    namespace = args[0]
+    try:
+        rospy.wait_for_service('/diagnostics_agg/remove_diagnostics', timeout=options.timeout)
+        remove_diagnostics = rospy.ServiceProxy('/diagnostics_agg/remove_diagnostics', RemoveDiagnostics)
+        resp = remove_diagnostics(namespc=namespace)
+        if resp.success:
+            rospy.loginfo('Successfully removed analyzers from diagnostics')
+        else:
+            rospy.loginfo('Did not remove any analyzers from diagnostics')
+    except rospy.ROSException:
+        rospy.logerr('Modify diagnostics delete timed out while waiting for diagnostics_agg service')
+
+def do_list():
+    try:
+        rospy.wait_for_service('/diagnostics_agg/remove_diagnostics')
+        list_diagnostics = rospy.ServiceProxy('/diagnostics_agg/list_diagnostics', ListDiagnostics)
+        resp = list_diagnostics()
+        for name in resp.names:
+            print(name)
+            
+    except rospy.ROSException:
+        rospy.logerr('Modify diagnostics list imed out while waiting for diagnostics_agg service')
+    
+    
+def print_usage():
+    print """modify_groups allows you to dynamically add or remove groups from the diagnostic aggregator
+Commands:
+\tmodify_groups add                  add analyzers to the aggregator
+\tmodify_groups delete               remove a namespace from the aggregator
+\tmodify_groups list                 list the paths of analyzers currently in the aggregator
+Type modify_groups <command> -h for more detailed usage, e.g. 'modify_groups add -h'
+"""
+    sys.exit(1)
+    
+if __name__ == '__main__':
+    # We don't need a node since the ServiceProxy can run without one, but then
+    # we lose logging information, so we lose out if we don't use one. It will
+    # be a short-lived node.
+    rospy.init_node('modify_diagnostics')
+    
+    myargv = rospy.myargv()
+    if len(myargv) == 1:
+        print_usage()
+    else:
+        cmd = myargv[1]
+        try:
+            if cmd == 'add':
+                do_add()
+            elif cmd == 'delete':
+                do_delete()
+            elif cmd == 'list':
+                do_list()
+            else:
+                print_usage()
+        except rospy.exceptions.ROSInterruptException:
+            pass

--- a/diagnostic_aggregator/test/launch/test_script.launch
+++ b/diagnostic_aggregator/test/launch/test_script.launch
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="diagnostic_aggregator" type="aggregator_node" name="diagnostic_aggregator">
+    <rosparam command="load" file="$(find diagnostic_aggregator)/test/expected_stale_analyzers.yaml"/>
+  </node>
+</launch>

--- a/diagnostic_aggregator/test/launch/test_script_add.launch
+++ b/diagnostic_aggregator/test/launch/test_script_add.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node pkg="diagnostic_aggregator" type="modify_diagnostics" name="modify_diagnostics" args="add $(find diagnostic_aggregator)/test/all_basic_analyzers.yaml /"/>
+</launch>

--- a/diagnostic_aggregator/test/launch/test_script_del.launch
+++ b/diagnostic_aggregator/test/launch/test_script_del.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node pkg="diagnostic_aggregator" type="modify_diagnostics" name="modify_diagnostics" args="delete /First"/>
+</launch>

--- a/diagnostic_aggregator/test/launch/test_script_list.launch
+++ b/diagnostic_aggregator/test/launch/test_script_list.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node pkg="diagnostic_aggregator" type="modify_diagnostics" name="modify_diagnostics" args="list"/>
+</launch>


### PR DESCRIPTION
See ros/common_msgs/pull/79 for the corresponding services used for functionality implemented here. This pull request implements the functionality mentioned in #31, but in a slightly different way since parameters must be loaded into a namespace before the service is called. Currently this is done in the `modify_diagnostics` script.

When adding new analyzers, the namespace to load from is specified in the service call, which a wrapper on the `init` function of the `AnalyzerGroup` uses to initialise a `NodeHandle`. The standard `init` function is then called with this modified handle which causes analyzers to be loaded from the specified namespace.

Deletion is done by recursively looking through the analyzers that are present and checking if their path is in the namespace which was sent in the service request. This means that a whole analyzer tree can be deleted by specifying the top level namespace.

Listing recursively aggregates all the paths into a vector which is then returned via the service response.

Any input on the changes would be much appreciated. In particular, I'm not sure if my changes in [`analyzer.h`](https://github.com/heuristicus/diagnostics/blob/hydro-devel/diagnostic_aggregator/include/diagnostic_aggregator/analyzer.h) make sense. The only other way I could think of implementing those recursive functions for use in [`analyzer_group.cpp`](https://github.com/heuristicus/diagnostics/blob/hydro-devel/diagnostic_aggregator/src/analyzer_group.cpp) without doing it this way was to check the class of the analyzer that was being looked at, and that seemed like a worse option.

I've not written any proper tests yet, but there are test launch files (those with the `test_script` prefix) which allow you to see the functionality at work.

`test_script.launch` will launch the `diagnostic_aggregator` with some default stuff loaded. You can then list those intial analyzers by running `test_script_list.launch`, or just `rosrun diagnostic_aggregator modify_diagnostics list`. Note that this won't show the `expected` analyzers, just those which exist. To add some analyzers to the aggregator, use `test_script_add.launch` and then list again - you should see that more analyzers have been added. You can then run the `test_script_del.launch` or `rosrun diagnostic_aggregator modify_diagnostics del /First` to delete one of the groups. The deletion is recursive, but isn't displayed by these tests since there isn't a test yaml which has a `AnalyzerGroup`. For the record, if you run things as I suggest, things should look something like the following:

    roslaunch diagnostic_aggregator test_script.launch

Then in another terminal:

    $ rosrun diagnostic_aggregator modify_diagnostics list
    /
    /My Path
    $ roslaunch diagnostic_aggregator test_script_add.launch
    $ rosrun diagnostic_aggregator modify_diagnostics list
    /
    /My Path
    /
    /First
    /Second
    /Third
    $ rosrun diagnostic_aggregator modify_diagnostics delete /First
    [INFO] [WallTime: 1441704184.793848] Successfully removed analyzers from diagnostics
    $ rosrun diagnostic_aggregator modify_diagnostics list
    /
    /My Path
    /
    /Second
    /Third

An additional `/` character is added to the list for each `AnalyzerGroup` added to the `Aggregator`.

There is also a thread on the drivers SIG [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/ros-sig-drivers/2lF1Wdi5ys4).