### PR TITLE
diagnostic_aggregator: Add functionality for dynamically adding analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+*.project
+*.cproject
+*.pydevproject
+

--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -3,16 +3,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(diagnostic_aggregator)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED diagnostic_msgs pluginlib roscpp rospy rostest xmlrpcpp)
-
-catkin_package(DEPENDS diagnostic_msgs pluginlib roscpp rospy xmlrpcpp
+find_package(catkin REQUIRED diagnostic_msgs pluginlib roscpp rospy rostest xmlrpcpp bondcpp)
+catkin_package(DEPENDS diagnostic_msgs pluginlib roscpp rospy xmlrpcpp bondcpp bondpy
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME})
 
-find_package(Boost REQUIRED COMPONENTS system regex)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-
-include_directories(include ${catkin_INCLUDE_DIRS} gtest-1.7.0/include)
+find_package(Boost REQUIRED COMPONENTS system)
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} gtest-1.7.0/include)
 
 add_library(${PROJECT_NAME}
   src/status_item.cpp
@@ -39,6 +36,7 @@ target_link_libraries(analyzer_loader diagnostic_aggregator)
 
 if(CATKIN_ENABLE_TESTING)
   add_rostest(test/launch/test_agg.launch)
+  add_rostest(test/launch/test_add_agg.launch)
 
   # Test Analyzer loader
   add_rostest(test/launch/test_loader.launch)
@@ -46,6 +44,10 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/launch/test_multiple_match.launch)
 endif()
 
+catkin_install_python(
+        PROGRAMS scripts/add_analyzers
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )

--- a/diagnostic_aggregator/demo/pr2_analyzers.yaml
+++ b/diagnostic_aggregator/demo/pr2_analyzers.yaml
@@ -1,44 +1,44 @@
 analyzers:
   motors:
-    type: GenericAnalyzer
+    type: diagnostic_aggregator/GenericAnalyzer
     path: Motors
     startswith: 'EtherCAT'
   sensors:
-    type: AnalyzerGroup
+    type: diagnostic_aggregator/AnalyzerGroup
     path: Sensors
     analyzers:
       base_hk:
-        type: GenericAnalyzer
+        type: diagnostic_aggregator/GenericAnalyzer
         path: Base Hokuyo
         timeout: 5.0
         find_and_remove_prefix: base_hokuyo_node
         num_items: 3
       tilt_hk:
-        type: GenericAnalyzer
+        type: diagnostic_aggregator/GenericAnalyzer
         path: Tilt Hokuyo
         timeout: 5.0
         find_and_remove_prefix: tilt_hokuyo_node
         num_items: 3
       imu:
-        type: GenericAnalyzer
+        type: diagnostic_aggregator/GenericAnalyzer
         path: IMU
         timeout: 5.0
         find_and_remove_prefix: imu_node
         num_items: 3
       forearm_cam_l:
-        type: GenericAnalyzer
+        type: diagnostic_aggregator/GenericAnalyzer
         path: Forearm Cam (Left)
         timeout: 5.0
         find_and_remove_prefix: l_forearm_cam
         num_items: 4
       forearm_cam_r:
-        type: GenericAnalyzer
+        type: diagnostic_aggregator/GenericAnalyzer
         path: Forearm Cam (Right)
         timeout: 5.0
         find_and_remove_prefix: r_forearm_cam
         num_items: 4
   computers:
-    type: GenericAnalyzer
+    type: diagnostic_aggregator/GenericAnalyzer
     path: Computers
     contains: [
       'HD Temp',
@@ -47,11 +47,11 @@ analyzers:
       'HD Usage',
       'NFS']
   joints:
-    type: GenericAnalyzer
+    type: diagnostic_aggregator/GenericAnalyzer
     path: Joints
     startswith: 'Joint'
   power:
-    type: GenericAnalyzer
+    type: diagnostic_aggregator/GenericAnalyzer
     path: 'Power System'
     timeout: 5.0
     startswith: [

--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.h
@@ -45,9 +45,12 @@
 #include <vector>
 #include <set>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
+#include <bondcpp/bond.h>
 #include <diagnostic_msgs/DiagnosticArray.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <diagnostic_msgs/KeyValue.h>
+#include <diagnostic_msgs/AddDiagnostics.h>
 #include "XmlRpcValue.h"
 #include "diagnostic_aggregator/analyzer.h"
 #include "diagnostic_aggregator/analyzer_group.h"
@@ -125,9 +128,11 @@ public:
 
 private:
   ros::NodeHandle n_;
+  ros::ServiceServer add_srv_; /**< AddDiagnostics, /diagnostics_agg/add_diagnostics */
   ros::Subscriber diag_sub_; /**< DiagnosticArray, /diagnostics */
   ros::Publisher agg_pub_;  /**< DiagnosticArray, /diagnostics_agg */
   ros::Publisher toplevel_state_pub_;  /**< DiagnosticStatus, /diagnostics_toplevel_state */
+  boost::mutex mutex_;
   double pub_rate_;
 
   /*!
@@ -135,9 +140,41 @@ private:
    */
   void diagCallback(const diagnostic_msgs::DiagnosticArray::ConstPtr& diag_msg);
 
+  /*!
+   *\brief Service request callback for addition of diagnostics.
+   * Creates a bond between the calling node and the aggregator, and loads
+   * information about new diagnostics into added_analyzers_, keeping track of
+   * the formed bond in bonds_
+   */
+  bool addDiagnostics(diagnostic_msgs::AddDiagnostics::Request &req,
+		      diagnostic_msgs::AddDiagnostics::Response &res);
+
   AnalyzerGroup* analyzer_group_;
 
   OtherAnalyzer* other_analyzer_;
+
+  std::vector<boost::shared_ptr<bond::Bond> > bonds_; /**< \brief Contains all bonds for additional diagnostics. */
+
+  /*
+   *!\brief called when a bond between the aggregator and a node is broken
+   *
+   * Modifies the contents of added_analyzers_ and analyzer_group, removing the
+   * diagnostics that had been brought up by that bond.
+   *!\param bond_id The bond id (namespace) from which the analyzer was created
+   *!\param analyzer Shared pointer to the analyzer group that was added
+   */
+  void bondBroken(std::string bond_id,
+		  boost::shared_ptr<Analyzer> analyzer);
+
+  /*
+   *!\brief called when a bond is formed between the aggregator and a node.
+   * Actually adds the analyzergroup to the main analyzer group. Before this
+   * function is called, the added diagnostics will not be analyzed by the
+   * aggregator.
+   *!\param group Shared pointer to the analyzer group that is to be added,
+   *  which was created in the addDiagnostics function
+   */
+  void bondFormed(boost::shared_ptr<Analyzer> group);
 
   std::string base_path_; /**< \brief Prepended to all status names of aggregator. */
 
@@ -148,6 +185,16 @@ private:
    */
   void checkTimestamp(const diagnostic_msgs::DiagnosticArray::ConstPtr& diag_msg);
 
+};
+
+/*
+ *!\brief Functor for checking whether a bond has the same ID as the given string
+ */
+struct BondIDMatch
+{
+  BondIDMatch(const std::string s) : s(s) {}
+  bool operator()(const boost::shared_ptr<bond::Bond>& b){ return s == b->getId(); }
+  const std::string s;
 };
 
 }

--- a/diagnostic_aggregator/include/diagnostic_aggregator/analyzer_group.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/analyzer_group.h
@@ -42,6 +42,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <algorithm>
 #include <ros/ros.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <diagnostic_msgs/KeyValue.h>
@@ -110,20 +111,35 @@ class AnalyzerGroup : public Analyzer
 {
 public:
   AnalyzerGroup();
-  
+
   virtual ~AnalyzerGroup();
 
   /*!
    *\brief Initialized with base path and namespace.
-   * 
+   *
    * The parameters in its namespace determine the sub-analyzers.
    */
   virtual bool init(const std::string base_path, const ros::NodeHandle &n);
+
+  /**!
+   *\brief Add an analyzer to this analyzerGroup
+   */
+  virtual bool addAnalyzer(boost::shared_ptr<Analyzer>& analyzer);
+
+  /**!
+   *\brief Remove an analyzer from this analyzerGroup
+   */
+  virtual bool removeAnalyzer(boost::shared_ptr<Analyzer>& analyzer);
 
   /*!
    *\brief Match returns true if any sub-analyzers match an item
    */
   virtual bool match(const std::string name);
+
+  /*!
+   *\brief Clear match arrays. Used when analyzers are added or removed
+   */
+  void resetMatches();
 
   /*!
    *\brief Analyze returns true if any sub-analyzers will analyze an item
@@ -136,7 +152,7 @@ public:
   virtual std::vector<boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> > report();
 
   virtual std::string getPath() const { return path_; }
-  
+
   virtual std::string getName() const { return nice_name_; }
 
 private:
@@ -155,7 +171,7 @@ private:
   std::vector<boost::shared_ptr<Analyzer> > analyzers_;
 
   /*
-   *\brief The map of names to matchings is stored internally. 
+   *\brief The map of names to matchings is stored internally.
    */
   std::map<const std::string, std::vector<bool> > matched_;
 

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
@@ -148,9 +148,9 @@ public:
     processed.push_back(header_status);
     
     bool all_stale = true;
-    
-    std::map<std::string, boost::shared_ptr<StatusItem> >::iterator it;
-    for (it = items_.begin(); it != items_.end(); it++)
+
+    std::map<std::string, boost::shared_ptr<StatusItem> >::iterator it = items_.begin();
+    while(it != items_.end())
     {
       std::string name = it->first;
       boost::shared_ptr<StatusItem> item = it->second;
@@ -162,7 +162,7 @@ public:
       // Erase item if its stale and we're discarding items
       if (discard_stale_ and stale)
       {
-        items_.erase(it);
+        items_.erase(it++);
         continue;
       }
       
@@ -183,6 +183,8 @@ public:
 
       if (stale)
         header_status->level = 3;
+
+      ++it;
     }
     
     // Header is not stale unless all subs are
@@ -216,9 +218,7 @@ public:
     
     return processed;
   }
-  
 
-  
   /*!
    *\brief Match function isn't implemented by GenericAnalyzerBase
    */

--- a/diagnostic_aggregator/package.xml
+++ b/diagnostic_aggregator/package.xml
@@ -20,12 +20,17 @@
   <build_depend>rospy</build_depend>
   <build_depend>rostest</build_depend>
   <build_depend>xmlrpcpp</build_depend>
+  <build_depend>bondcpp</build_depend>
+  <build_depend>bondpy</build_depend>
 
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>xmlrpcpp</run_depend>
+  <run_depend>bondcpp</run_depend>
+  <run_depend>bondpy</run_depend>
+
 
   <!-- <test_depend>diagnostic_msgs</test_depend> -->
   <!-- <test_depend>roscpp</test_depend> -->

--- a/diagnostic_aggregator/scripts/add_analyzers
+++ b/diagnostic_aggregator/scripts/add_analyzers
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+NAME='add_analyzers'
+
+import sys
+import argparse
+from bondpy import bondpy
+from diagnostic_msgs.srv import AddDiagnostics
+import rosparam
+import rospy
+
+class AddAnalyzers:
+
+    def __init__(self, args):
+        rospy.on_shutdown(self.remove_group)
+        self.bond = None
+        self.add_analyzers(args)
+
+    def remove_group(self):
+        if self.bond:
+            self.bond.shutdown()
+
+    def add_analyzers(self, myargv):
+        usage = """
+        allows you to dynamically add a group to the diagnostic aggregator,
+        which is automatically removed when this node dies. Analyzer configurations
+        can either be provided directly, or assumed that they are already can be
+        found on the ros parameter server (where roslaunch may have loaded them).
+        """
+        parser = argparse.ArgumentParser(description=usage)
+        parser.add_argument('analyzer_yaml', nargs='?', default=None)
+        parser.add_argument('-t', '--timeout', type=float, dest='timeout', default=None, help='time in seconds to wait for the diagnostic_agg service to come up before timing out. Default waits indefinitely')
+        args = parser.parse_args(myargv[1:])
+
+        namespace = rospy.resolve_name(rospy.get_name())
+
+        if args.analyzer_yaml is None:
+            # nothing to do - it will assume parameters are already loaded on
+            # the parameter server (usually via roslaunch)
+            pass
+        else:
+            paramlist = rosparam.load_file(args.analyzer_yaml, default_namespace=namespace)
+            for params, ns in paramlist:
+                rosparam.upload_params(ns, params)
+
+        self.bond = bondpy.Bond("/diagnostics_agg/bond", namespace)
+        self.bond.start()
+
+        try:
+            rospy.wait_for_service('/diagnostics_agg/add_diagnostics', timeout=args.timeout)
+            add_diagnostics = rospy.ServiceProxy('/diagnostics_agg/add_diagnostics', AddDiagnostics)
+            resp = add_diagnostics(load_namespace=namespace)
+            if resp.success:
+                rospy.loginfo(NAME + ' successfully added analyzers to diagnostic aggregator')
+            else:
+                rospy.logerr(NAME + ' did not add any analyzers to diagnostic aggregator: ' + resp.message)
+                rospy.signal_shutdown('')
+        except rospy.service.ServiceException:
+            rospy.logerr(NAME + ' service returned failure - missing aggregator or failed init of analyzer group?')
+            rospy.signal_shutdown('')
+        except rospy.ROSException:
+            rospy.logerr(NAME + ' add timed out while waiting for diagnostics_agg service, or ROS shutdown')
+            rospy.signal_shutdown('')
+
+        rospy.spin()
+
+if __name__ == '__main__':
+    rospy.init_node(NAME)
+    AddAnalyzers(rospy.myargv())

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -51,19 +51,18 @@ Aggregator::Aggregator() :
     base_path_ = "/" + base_path_;
 
   nh.param("pub_rate", pub_rate_, pub_rate_);
-    
+
   analyzer_group_ = new AnalyzerGroup();
-  
+
   if (!analyzer_group_->init(base_path_, nh))
   {
     ROS_ERROR("Analyzer group for diagnostic aggregator failed to initialize!");
   }
-  
 
   // Last analyzer handles remaining data
   other_analyzer_ = new OtherAnalyzer();
   other_analyzer_->init(base_path_); // This always returns true
-
+  add_srv_ = n_.advertiseService("/diagnostics_agg/add_diagnostics", &Aggregator::addDiagnostics, this);
   diag_sub_ = n_.subscribe("/diagnostics", 1000, &Aggregator::diagCallback, this);
   agg_pub_ = n_.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics_agg", 1);
   toplevel_state_pub_ = n_.advertise<diagnostic_msgs::DiagnosticStatus>("/diagnostics_toplevel_state", 1);
@@ -92,26 +91,106 @@ void Aggregator::checkTimestamp(const diagnostic_msgs::DiagnosticArray::ConstPtr
 
 void Aggregator::diagCallback(const diagnostic_msgs::DiagnosticArray::ConstPtr& diag_msg)
 {
-  checkTimestamp(diag_msg);  
+  checkTimestamp(diag_msg);
 
   bool analyzed = false;
-  for (unsigned int j = 0; j < diag_msg->status.size(); ++j)
-  {
-    analyzed = false;
-    boost::shared_ptr<StatusItem> item(new StatusItem(&diag_msg->status[j]));
-    if (analyzer_group_->match(item->getName()))
-      analyzed = analyzer_group_->analyze(item);
+  { // lock the whole loop to ensure nothing in the analyzer group changes
+    // during it.
+    boost::mutex::scoped_lock lock(mutex_);
+    for (unsigned int j = 0; j < diag_msg->status.size(); ++j)
+    {
+      analyzed = false;
+      boost::shared_ptr<StatusItem> item(new StatusItem(&diag_msg->status[j]));
 
-    if (!analyzed)
-      other_analyzer_->analyze(item);
+      if (analyzer_group_->match(item->getName()))
+	analyzed = analyzer_group_->analyze(item);
+
+      if (!analyzed)
+	other_analyzer_->analyze(item);
+    }
   }
 }
 
-Aggregator::~Aggregator() 
+Aggregator::~Aggregator()
 {
   if (analyzer_group_) delete analyzer_group_;
 
   if (other_analyzer_) delete other_analyzer_;
+}
+
+
+void Aggregator::bondBroken(string bond_id, boost::shared_ptr<Analyzer> analyzer)
+{
+  boost::mutex::scoped_lock lock(mutex_); // Possibility of multiple bonds breaking at once
+  ROS_DEBUG("Bond for namespace %s was broken", bond_id.c_str());
+  std::vector<boost::shared_ptr<bond::Bond> >::iterator elem;
+  elem = std::find_if(bonds_.begin(), bonds_.end(), BondIDMatch(bond_id));
+  if (elem == bonds_.end()){
+    ROS_WARN("Broken bond tried to erase a bond which didn't exist.");
+  } else {
+    bonds_.erase(elem);
+  }
+  if (!analyzer_group_->removeAnalyzer(analyzer))
+  {
+    ROS_WARN("Broken bond tried to remove an analyzer which didn't exist.");
+  }
+
+  analyzer_group_->resetMatches();
+}
+
+void Aggregator::bondFormed(boost::shared_ptr<Analyzer> group){
+  ROS_DEBUG("Bond formed");
+  boost::mutex::scoped_lock lock(mutex_);
+  analyzer_group_->addAnalyzer(group);
+  analyzer_group_->resetMatches();
+}
+
+bool Aggregator::addDiagnostics(diagnostic_msgs::AddDiagnostics::Request &req,
+				diagnostic_msgs::AddDiagnostics::Response &res)
+{
+  ROS_DEBUG("Got load request for namespace %s", req.load_namespace.c_str());
+  // Don't currently support relative or private namespace definitions
+  if (req.load_namespace[0] != '/')
+  {
+    res.message = "Requested load from non-global namespace. Private and relative namespaces are not supported.";
+    res.success = false;
+    return true;
+  }
+
+  boost::shared_ptr<Analyzer> group = boost::make_shared<AnalyzerGroup>();
+  { // lock here ensures that bonds from the same namespace aren't added twice.
+    // Without it, possibility of two simultaneous calls adding two objects.
+    boost::mutex::scoped_lock lock(mutex_);
+    // rebuff attempts to add things from the same namespace twice
+    if (std::find_if(bonds_.begin(), bonds_.end(), BondIDMatch(req.load_namespace)) != bonds_.end())
+    {
+      res.message = "Requested load from namespace " + req.load_namespace + " which is already in use";
+      res.success = false;
+      return true;
+    }
+
+    boost::shared_ptr<bond::Bond> req_bond = boost::make_shared<bond::Bond>(
+      "/diagnostics_agg/bond", req.load_namespace,
+      boost::function<void(void)>(boost::bind(&Aggregator::bondBroken, this, req.load_namespace, group)),
+      boost::function<void(void)>(boost::bind(&Aggregator::bondFormed, this, group))
+									    );
+    req_bond->start();
+
+    bonds_.push_back(req_bond); // bond formed, keep track of it
+  }
+
+  if (group->init(base_path_, ros::NodeHandle(req.load_namespace)))
+  {
+    res.message = "Successfully initialised AnalyzerGroup. Waiting for bond to form.";
+    res.success = true;
+    return true;
+  }
+  else
+  {
+    res.message = "Failed to initialise AnalyzerGroup.";
+    res.success = false;
+    return true;
+  }
 }
 
 void Aggregator::publishData()
@@ -122,8 +201,12 @@ void Aggregator::publishData()
   diag_toplevel_state.name = "toplevel_state";
   diag_toplevel_state.level = -1;
   int min_level = 255;
-
-  vector<boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> > processed = analyzer_group_->report();
+  
+  vector<boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> > processed;
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    processed = analyzer_group_->report();
+  }
   for (unsigned int i = 0; i < processed.size(); ++i)
   {
     diag_array.status.push_back(*processed[i]);
@@ -133,7 +216,7 @@ void Aggregator::publishData()
     if (processed[i]->level < min_level)
       min_level = processed[i]->level;
   }
- 
+
   vector<boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> > processed_other = other_analyzer_->report();
   for (unsigned int i = 0; i < processed_other.size(); ++i)
   {

--- a/diagnostic_aggregator/src/analyzer_group.cpp
+++ b/diagnostic_aggregator/src/analyzer_group.cpp
@@ -154,7 +154,7 @@ bool AnalyzerGroup::init(const string base_path, const ros::NodeHandle &n)
   if (analyzers_.size() == 0)
   {
     init_ok = false;
-    ROS_ERROR("No analyzers initialzed in AnalyzerGroup %s", analyzers_nh.getNamespace().c_str());
+    ROS_ERROR("No analyzers initialized in AnalyzerGroup %s", analyzers_nh.getNamespace().c_str());
   }
 
   return init_ok;
@@ -163,6 +163,23 @@ bool AnalyzerGroup::init(const string base_path, const ros::NodeHandle &n)
 AnalyzerGroup::~AnalyzerGroup()
 {
   analyzers_.clear();
+}
+
+bool AnalyzerGroup::addAnalyzer(boost::shared_ptr<Analyzer>& analyzer)
+{
+  analyzers_.push_back(analyzer);
+  return true;
+}
+
+bool AnalyzerGroup::removeAnalyzer(boost::shared_ptr<Analyzer>& analyzer)
+{
+  vector<boost::shared_ptr<Analyzer> >::iterator it = find(analyzers_.begin(), analyzers_.end(), analyzer);
+  if (it != analyzers_.end())
+  {
+    analyzers_.erase(it);
+    return true;
+  }
+  return false;
 }
 
 bool AnalyzerGroup::match(const string name)
@@ -192,6 +209,12 @@ bool AnalyzerGroup::match(const string name)
 
   return match_name;
 }
+
+void AnalyzerGroup::resetMatches()
+{
+  matched_.clear();
+}
+
 
 bool AnalyzerGroup::analyze(const boost::shared_ptr<StatusItem> item)
 {

--- a/diagnostic_aggregator/test/add_analyzers.yaml
+++ b/diagnostic_aggregator/test/add_analyzers.yaml
@@ -1,0 +1,9 @@
+analyzers:
+  primary:
+    type: 'diagnostic_aggregator/GenericAnalyzer'
+    path: Primary
+    startswith: 'primary'
+  secondary:
+    type: 'diagnostic_aggregator/GenericAnalyzer'
+    path: Secondary
+    startswith: 'secondary'

--- a/diagnostic_aggregator/test/add_analyzers_test.py
+++ b/diagnostic_aggregator/test/add_analyzers_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2009, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+import rospy, rostest
+import rosparam
+import optparse
+import sys
+import threading
+from bondpy import bondpy
+from diagnostic_msgs.srv import AddDiagnostics
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
+
+PKG = 'diagnostic_aggregator'
+
+class TestAddAnalyzer(unittest.TestCase):
+    def __init__(self, *args):
+        super(TestAddAnalyzer, self).__init__(*args)
+        rospy.init_node('test_add_analyzer')
+        self.namespace = rospy.get_name()
+        paramlist = rosparam.load_file(rospy.myargv()[1])
+        # expect to receive these paths in the added analyzers
+        self.expected = [paramlist[0][1] + analyzer['path'] for name, analyzer in paramlist[0][0]['analyzers'].iteritems()]
+
+        self._mutex = threading.Lock()
+        self.agg_msgs = {}
+
+        # put parameters in the node namespace so they can be read by the aggregator
+        for params, ns in paramlist:
+            rosparam.upload_params(rospy.get_name() + '/' + ns, params)
+
+        rospy.Subscriber('/diagnostics_agg', DiagnosticArray, self.agg_cb)
+        self.pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=1)
+
+    def agg_cb(self, msg):
+        with self._mutex:
+            for stat in msg.status:
+                self.agg_msgs[stat.name] = stat
+
+    def add_analyzer(self):
+        """Start a bond to the aggregator
+        """
+        self.bond = bondpy.Bond("/diagnostics_agg/bond", rospy.resolve_name(rospy.get_name()))
+        self.bond.start()
+        rospy.wait_for_service('/diagnostics_agg/add_diagnostics', timeout=10)
+        add_diagnostics = rospy.ServiceProxy('/diagnostics_agg/add_diagnostics', AddDiagnostics)
+        print(self.namespace)
+        resp = add_diagnostics(load_namespace=self.namespace)
+        self.assert_(resp.success, 'Service call was unsuccessful: {0}'.format(resp.message))
+
+    def wait_for_agg(self):
+        self.agg_msgs = {}
+        while not self.agg_msgs and not rospy.is_shutdown():
+            rospy.sleep(rospy.Duration(3))
+
+    def test_add_agg(self):
+        self.wait_for_agg()
+
+        # confirm that the things we're going to add aren't there already
+        with self._mutex:
+            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+            self.assert_(not any(expected in agg_paths for expected in self.expected))
+            
+        # add the new groups
+        self.add_analyzer()
+
+        arr = DiagnosticArray()
+        arr.header.stamp = rospy.get_rostime()
+        arr.status = [
+            DiagnosticStatus(name='primary', message='hello-primary'),
+            DiagnosticStatus(name='secondary', message='hello-secondary')
+        ]
+        self.pub.publish(arr)
+        self.wait_for_agg()
+        # the new aggregator data should contain the extra paths. At this point
+        # the paths are probably still in the 'Other' group because the bond
+        # hasn't been fully formed
+        with self._mutex:
+            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+            self.assert_(all(expected in agg_paths for expected in self.expected))
+
+        rospy.sleep(rospy.Duration(5)) # wait a bit for the new items to move to the right group
+        arr.header.stamp = rospy.get_rostime()
+        self.pub.publish(arr) # publish again to get the correct groups to show OK
+        self.wait_for_agg()
+
+        for name, msg in self.agg_msgs.iteritems():
+            if name in self.expected: # should have just received messages on the analyzer
+                self.assert_(msg.message == 'OK')
+                
+            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+            self.assert_(all(expected in agg_paths for expected in self.expected))
+                
+
+        self.bond.shutdown()
+        self.wait_for_agg()
+        # the aggregator data should no longer contain the paths once the bond is shut down
+        with self._mutex:
+            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+            self.assert_(not any(expected in agg_paths for expected in self.expected))
+        
+if __name__ == '__main__':
+    print 'SYS ARGS:', sys.argv
+    rostest.run(PKG, sys.argv[0], TestAddAnalyzer, sys.argv)

--- a/diagnostic_aggregator/test/launch/test_add_agg.launch
+++ b/diagnostic_aggregator/test/launch/test_add_agg.launch
@@ -1,0 +1,10 @@
+<launch>
+  <node pkg="diagnostic_aggregator" type="aggregator_node" name="diag_agg" output="screen">
+    <rosparam command="load" file="$(find diagnostic_aggregator)/test/simple_analyzers.yaml" />
+  </node>
+
+  <test test-name="add-test" pkg="diagnostic_aggregator" type="add_analyzers_test.py"
+        name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml"/>
+  <!-- <node pkg="diagnostic_aggregator" type="add_analyzers_test.py" -->
+  <!--       name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml"/> -->
+</launch>

--- a/diagnostic_aggregator/test/launch/test_script_add.launch
+++ b/diagnostic_aggregator/test/launch/test_script_add.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node pkg="diagnostic_aggregator" type="add_analyzers" name="add_analyzers" args="$(find diagnostic_aggregator)/test/multiple_match_analyzers.yaml"/>
+</launch>


### PR DESCRIPTION
New proposal based on the bond framework as suggested by @trainman419.

The diagnostic aggregator now has a single service, which receives information about the namespace from which to load aggregator information. A new `AnalyzerGroup` is created and added to the main `AnalyzerGroup` of the aggregator. At the same time, a bond is formed between the node which requested the diagnostics be added and the aggregator. When this bond is broken, the additional diagnostic capabilities that were added are removed.

Simple tests can be run with the following commands:

```
roslaunch diagnostic_aggregator aggregator.launch
rosrun rqt_robot_monitor rqt_robot_monitor
rosrun diagnostic_aggregator add_analyzers diagnostics/diagnostic_aggregator/test/all_basic_analyzers.yaml
rosrun diagnostic_aggregator add_analyzers diagnostics/diagnostic_aggregator/test/multiple_match_analyzers.yaml __name:=testing
```

In different terminals, of course. The `add_analyzers` script adds analyzers based on the given parameters in the yaml files. In this specific case, the robot monitor will display the additional groups `First` and `Second` from the first run of `add_analyzers`, and `Header1` and `Header2` from the second run. The parameters from those files are loaded into the node namespace, which is passed to the aggregator via a service. The aggregator uses that namespace to create a new analyzer group. Cancelling execution in those terminals will remove the added groups from the monitor.

The required service message is in ros/common_msgs#80.

There is a discussion at [`ros-sig-drivers`](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/ros-sig-drivers/2lF1Wdi5ys4).