### PR TITLE
Start bond after add_diagnostics service is available

### DIFF
--- a/diagnostic_aggregator/scripts/add_analyzers
+++ b/diagnostic_aggregator/scripts/add_analyzers
@@ -44,10 +44,10 @@ class AddAnalyzers:
                 rosparam.upload_params(ns, params)
 
         self.bond = bondpy.Bond("/diagnostics_agg/bond", namespace)
-        self.bond.start()
 
         try:
             rospy.wait_for_service('/diagnostics_agg/add_diagnostics', timeout=args.timeout)
+            self.bond.start()
             add_diagnostics = rospy.ServiceProxy('/diagnostics_agg/add_diagnostics', AddDiagnostics)
             resp = add_diagnostics(load_namespace=namespace)
             if resp.success:


### PR DESCRIPTION
Right now, it is possible for `diagnostic_aggregator` to not add analyzers from a `add_analyzer` node in some cases even though all nodes are up and running.

Bond has a connection timeout duration and so if the `diag_agg` node launches `<connection_timeout>` secs after the `add_analyzer` node has been launched (or vice versa), the analyzers from `add_analyzers` are not added as the bond is considered broken.

If we start bond after the `/diagnostics_agg/add_diagnostics` service is available, we know for sure that the `diag_agg` node has been launched.