### PR TITLE
Source the environment when running Travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - cmake .. -DCMAKE_INSTALL_PREFIX=./install
   - make -j1
   - make -j1 tests
-  - make -j1 run_tests
+  - devel/env.sh make -j1 run_tests
   - catkin_test_results .
   - make -j1 install
 notifications:


### PR DESCRIPTION
This should fix the test failures which look like this:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/loader.py", line 411, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/travis/build/ros/diagnostics/diagnostic_analysis/test/bag_csv_test.py", line 51, in <module>
    from diagnostic_analysis.exporter import LogExporter
ImportError: No module named diagnostic_analysis.exporter
```