### PR TITLE
Remove warning for missing queue size specification

### DIFF
--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/ntp_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/ntp_monitor.py
@@ -115,7 +115,7 @@ class NTPMonitor:
         self.self_stat.values = []
 
         self.mutex = threading.Lock()
-        self.pub = rospy.Publisher("/diagnostics", DIAG.DiagnosticArray)
+        self.pub = rospy.Publisher("/diagnostics", DIAG.DiagnosticArray, queue_size=10)
 
         # we need to periodically republish this
         self.current_msg = None


### PR DESCRIPTION
PR to remove the warning due to missing queue size. 
Added a default value of 10 as this is diagnostics and would help not to lose info. Please let me know if this would cause issues with backward compatibility in any way.