### PR TITLE
Stability Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 dist: trusty
 language: generic
+group: deprecated-2017Q3
 compiler:
   - gcc
 # install dependencies

--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.h
@@ -86,6 +86,7 @@ Output:
 \verbatim
 base_path: My Robot
 pub_rate: 1.0
+other_as_errors: false
 analyzers:
   sensors:
     type: GenericAnalyzer
@@ -97,7 +98,7 @@ analyzers:
     type: PR2JointsAnalyzer
 \endverbatim
  * Each analyzer is created according to the "type" parameter in its namespace.
- * Any other parametes in the namespace can by used to specify the analyzer. If
+ * Any other parameters in the namespace can by used to specify the analyzer. If
  * any analyzer is not properly specified, or returns false on initialization,
  * the aggregator will report the error and publish it in the aggregated output.
  */

--- a/diagnostic_aggregator/include/diagnostic_aggregator/other_analyzer.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/other_analyzer.h
@@ -63,7 +63,9 @@ public:
   /*!
    *\brief Default constructor. OtherAnalyzer isn't loaded by pluginlib
    */
-  OtherAnalyzer() { }
+  explicit OtherAnalyzer(bool other_as_errors = false)
+  : other_as_errors_(other_as_errors)
+  { }
 
   ~OtherAnalyzer() { }
 
@@ -105,10 +107,29 @@ public:
 
     // We don't report anything if there's no "Other" items
     if (processed.size() == 1)
+    {
       processed.clear();
+    }
+    // "Other" items are considered an error.
+    else if (other_as_errors_ && processed.size() > 1)
+    {
+      std::vector<boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> >::iterator it = processed.begin();
+      for (; it != processed.end(); ++it)
+      {
+        if ((*it)->name == path_)
+        {
+          (*it)->level = 2;
+          (*it)->message = "Unanalyzed items found in \"Other\"";
+          break;
+        }
+      }
+    }
     
     return processed;
   }
+
+private:
+  bool other_as_errors_;
 };
 
 }

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -52,6 +52,9 @@ Aggregator::Aggregator() :
 
   nh.param("pub_rate", pub_rate_, pub_rate_);
 
+  bool other_as_errors = false;
+  nh.param("other_as_errors", other_as_errors, false);
+
   analyzer_group_ = new AnalyzerGroup();
 
   if (!analyzer_group_->init(base_path_, nh))
@@ -60,7 +63,7 @@ Aggregator::Aggregator() :
   }
 
   // Last analyzer handles remaining data
-  other_analyzer_ = new OtherAnalyzer();
+  other_analyzer_ = new OtherAnalyzer(other_as_errors);
   other_analyzer_->init(base_path_); // This always returns true
   add_srv_ = n_.advertiseService("/diagnostics_agg/add_diagnostics", &Aggregator::addDiagnostics, this);
   diag_sub_ = n_.subscribe("/diagnostics", 1000, &Aggregator::diagCallback, this);

--- a/diagnostic_aggregator/test/add_analyzers_test.py
+++ b/diagnostic_aggregator/test/add_analyzers_test.py
@@ -71,7 +71,8 @@ class TestAddAnalyzer(unittest.TestCase):
     def add_analyzer(self):
         """Start a bond to the aggregator
         """
-        self.bond = bondpy.Bond("/diagnostics_agg/bond", rospy.resolve_name(rospy.get_name()))
+        namespace = rospy.resolve_name(rospy.get_name())
+        self.bond = bondpy.Bond("/diagnostics_agg/bond" + namespace, namespace)
         self.bond.start()
         rospy.wait_for_service('/diagnostics_agg/add_diagnostics', timeout=10)
         add_diagnostics = rospy.ServiceProxy('/diagnostics_agg/add_diagnostics', AddDiagnostics)

--- a/diagnostic_aggregator/test/diag_pub.py
+++ b/diagnostic_aggregator/test/diag_pub.py
@@ -48,7 +48,7 @@ from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 
 if __name__ == '__main__':
     rospy.init_node('diag_pub')
-    pub = rospy.Publisher('/diagnostics', DiagnosticArray)
+    pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=10)
     
     array = DiagnosticArray()
     array.status = [

--- a/diagnostic_aggregator/test/expected_stale_pub.py
+++ b/diagnostic_aggregator/test/expected_stale_pub.py
@@ -48,7 +48,7 @@ from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 
 if __name__ == '__main__':
     rospy.init_node('diag_pub')
-    pub = rospy.Publisher('/diagnostics', DiagnosticArray)
+    pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=10)
     
     start_time = rospy.get_time()
     

--- a/diagnostic_aggregator/test/multiple_match_pub.py
+++ b/diagnostic_aggregator/test/multiple_match_pub.py
@@ -48,7 +48,7 @@ from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 
 if __name__ == '__main__':
     rospy.init_node('diag_pub')
-    pub = rospy.Publisher('/diagnostics', DiagnosticArray)
+    pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=10)
     
     start_time = rospy.get_time()
     

--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/hd_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/hd_monitor.py
@@ -140,7 +140,7 @@ class hd_monitor():
             rospy.logwarn('Not warning for HD temperatures is deprecated. This will be removed in D-turtle')
         self._home_dir = home_dir
 
-        self._diag_pub = rospy.Publisher('/diagnostics', DiagnosticArray)
+        self._diag_pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=10)
 
         self._last_temp_time = 0
         self._last_usage_time = 0

--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
@@ -42,6 +42,7 @@ import socket, string
 import subprocess
 import math
 import re
+import sys
 from StringIO import StringIO
 
 class Sensor(object):

--- a/diagnostic_updater/src/diagnostic_updater/_diagnostic_status_wrapper.py
+++ b/diagnostic_updater/src/diagnostic_updater/_diagnostic_status_wrapper.py
@@ -36,8 +36,6 @@
 @author Brice Rebsamen <brice [dot] rebsamen [gmail]>
 """
 
-import roslib
-roslib.load_manifest('diagnostic_updater')
 import rospy
 from diagnostic_msgs.msg import DiagnosticStatus, KeyValue
 

--- a/diagnostic_updater/src/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/src/diagnostic_updater/_diagnostic_updater.py
@@ -36,8 +36,6 @@
 @author Brice Rebsamen <brice [dot] rebsamen [gmail]>
 """
 
-import roslib
-roslib.load_manifest('diagnostic_updater')
 import rospy
 import threading, httplib
 from diagnostic_msgs.msg import DiagnosticArray

--- a/diagnostic_updater/src/diagnostic_updater/_publisher.py
+++ b/diagnostic_updater/src/diagnostic_updater/_publisher.py
@@ -36,8 +36,6 @@
 @author Brice Rebsamen <brice [dot] rebsamen [gmail]>
 """
 
-import roslib
-roslib.load_manifest('diagnostic_updater')
 import rospy
 import threading
 from ._update_functions import *

--- a/diagnostic_updater/src/diagnostic_updater/_update_functions.py
+++ b/diagnostic_updater/src/diagnostic_updater/_update_functions.py
@@ -36,8 +36,6 @@
 @author Brice Rebsamen <brice [dot] rebsamen [gmail]>
 """
 
-import roslib
-roslib.load_manifest('diagnostic_updater')
 import rospy
 from ._diagnostic_updater import *
 

--- a/diagnostic_updater/src/example.py
+++ b/diagnostic_updater/src/example.py
@@ -190,8 +190,8 @@ if __name__=='__main__':
     # is in a special state.
     updater.broadcast(0, "Doing important initialization stuff.")
 
-    pub1 = rospy.Publisher("topic1", std_msgs.msg.Bool)
-    pub2_temp = rospy.Publisher("topic2", std_msgs.msg.Bool)
+    pub1 = rospy.Publisher("topic1", std_msgs.msg.Bool, queue_size=10)
+    pub2_temp = rospy.Publisher("topic2", std_msgs.msg.Bool, queue_size=10)
     rospy.sleep(2) # It isn't important if it doesn't take time.
 
     # Some diagnostic tasks are very common, such as checking the rate

--- a/test_diagnostic_aggregator/test/match_analyze_pub.py
+++ b/test_diagnostic_aggregator/test/match_analyze_pub.py
@@ -45,7 +45,7 @@ from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 
 if __name__ == '__main__':
     rospy.init_node('diag_pub')
-    pub = rospy.Publisher('/diagnostics', DiagnosticArray)
+    pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=10)
         
     while not rospy.is_shutdown():
         array = DiagnosticArray()


### PR DESCRIPTION
 * Python updates to remove obsolete manifest loading
 * Option to make diagnostics in the Other Analyzer an Error
 * Warning message when add_analyzers bond is broken
 * Per-bond topics for add_analyzers to avoid queue length issues

We've been running these changes on our robots for the past 2-3 months.