### PR TITLE
Fix per-bond topic name in add_analyzers.

### DIFF
--- a/diagnostic_aggregator/scripts/add_analyzers
+++ b/diagnostic_aggregator/scripts/add_analyzers
@@ -43,7 +43,7 @@ class AddAnalyzers:
             for params, ns in paramlist:
                 rosparam.upload_params(ns, params)
 
-        self.bond = bondpy.Bond("/diagnostics_agg/bond", namespace)
+        self.bond = bondpy.Bond("/diagnostics_agg/bond" + namespace, namespace)
 
         try:
             rospy.wait_for_service('/diagnostics_agg/add_diagnostics', timeout=args.timeout)


### PR DESCRIPTION
This PR fixes the bond topic name mismatch in the add_analyzers script caused by https://github.com/Jin-Myung/diagnostics/commit/a6ea1b6e1c8062d044ae28d172aea6d4305065aa.