### PR TITLE
adapt to new xmlrpcpp header location

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.h
@@ -51,7 +51,7 @@
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <diagnostic_msgs/KeyValue.h>
 #include <diagnostic_msgs/AddDiagnostics.h>
-#include "XmlRpcValue.h"
+#include "xmlrpcpp/XmlRpcValue.h"
 #include "diagnostic_aggregator/analyzer.h"
 #include "diagnostic_aggregator/analyzer_group.h"
 #include "diagnostic_aggregator/status_item.h"

--- a/diagnostic_aggregator/include/diagnostic_aggregator/analyzer_group.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/analyzer_group.h
@@ -48,7 +48,7 @@
 #include <diagnostic_msgs/KeyValue.h>
 #include "diagnostic_aggregator/status_item.h"
 #include <boost/shared_ptr.hpp>
-#include "XmlRpcValue.h"
+#include "xmlrpcpp/XmlRpcValue.h"
 #include "diagnostic_aggregator/analyzer.h"
 #include "diagnostic_aggregator/status_item.h"
 #include "pluginlib/class_loader.h"

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer.h
@@ -52,7 +52,7 @@
 #include "diagnostic_aggregator/analyzer.h"
 #include "diagnostic_aggregator/status_item.h"
 #include "diagnostic_aggregator/generic_analyzer_base.h"
-#include "XmlRpcValue.h"
+#include "xmlrpcpp/XmlRpcValue.h"
 
 namespace diagnostic_aggregator {
 


### PR DESCRIPTION
Without this `diagnostic_aggregator` fails to compile from source using `catkin build` or `catkin_make_isolated --merge`.

Note that this is applicable only to kinetic and later at the moment. A request for having the same header location for all distros has been submitted [here](https://github.com/ros/ros_comm/issues/1315)