### PR TITLE
Add a simple Heartbeat-DiagnosticTask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
-  - sudo apt-get install python-rosdep ros-indigo-catkin python-catkin-pkg
+  - sudo apt-get install python-rosdep ros-indigo-catkin
   - sudo `which rosdep` init
   - rosdep update
   # use rosdep to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
-  - sudo apt-get install python-rosdep ros-indigo-catkin
+  - sudo apt-get install python-rosdep ros-indigo-catkin python-catkin-pkg
   - sudo `which rosdep` init
   - rosdep update
   # use rosdep to install dependencies

--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -376,6 +376,29 @@ namespace diagnostic_updater
       boost::mutex lock_;
   };
 
+ /**
+ * \brief Diagnostic task to monitor whether a node is alive
+ *
+ * This diagnostic task always reports as OK and 'Alive' when it runs
+ */
+
+  class Heartbeat : public DiagnosticTask
+  {
+  public:
+    /**
+     * \brief Constructs a HeartBeat
+     */
+
+    Heartbeat() :
+      DiagnosticTask("Heartbeat")
+    {
+    }
+
+    virtual void run(diagnostic_updater::DiagnosticStatusWrapper &stat)
+    {
+      stat.summary(0, "Alive");
+    }
+  };
 };
 
 #endif

--- a/diagnostic_updater/src/diagnostic_updater/_update_functions.py
+++ b/diagnostic_updater/src/diagnostic_updater/_update_functions.py
@@ -218,3 +218,18 @@ class TimeStampStatus(DiagnosticTask):
             self.zero_seen = False
 
         return stat
+
+
+class Heartbeat(DiagnosticTask):
+    """Diagnostic task to monitor whether a node is alive
+
+    This diagnostic task always reports as OK and 'Alive' when it runs
+    """
+
+    def __init__(self):
+        """Constructs a HeartBeat"""
+        DiagnosticTask.__init__(self, "Heartbeat")
+
+    def run(self, stat):
+        stat.summary(0, "Alive")
+        return stat


### PR DESCRIPTION
Basic use-case for me is to simply know whether a node is alive or not. The reason to build this is we have  a NVidia Jetson board running a ROS service. Sometimes the board isn't booting for whatever reason. Simply broadcasting "I'm alive!" already helps in detecting that. 

It's a service, so various existing DiagnosticTasks do not make sense. 

Example use is in https://github.com/tue-robotics/image_recognition/pull/55