### PR TITLE
Install python-catkin-pkg to fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 dist: trusty
 language: generic
-group: deprecated-2017Q3
 compiler:
   - gcc
 # install dependencies
@@ -11,7 +10,7 @@ install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
-  - sudo apt-get install python-rosdep ros-indigo-catkin
+  - sudo apt-get install python-catkin-pkg python-rosdep ros-indigo-catkin
   - sudo `which rosdep` init
   - rosdep update
   # use rosdep to install dependencies


### PR DESCRIPTION
Travis CI fails because the catkin_pkg module is not installed. Install it to fix travis.

This also reverts the previous hardcoding of the build environment to a deprecated type. now that Trusty builds seem to be working correctly on Travis again.