### PR TITLE
Fixed base_path handling

### DIFF
--- a/diagnostic_aggregator/src/analyzer_group.cpp
+++ b/diagnostic_aggregator/src/analyzer_group.cpp
@@ -53,7 +53,10 @@ bool AnalyzerGroup::init(const string base_path, const ros::NodeHandle &n)
   n.param("path", nice_name_, string(""));
   
   if (base_path.size() > 0 && base_path != "/")
-    path_ = base_path + "/" + nice_name_;
+    if (nice_name_.size() > 0)
+      path_ = base_path + "/" + nice_name_;
+    else
+      path_ = base_path;
   else
     path_ = nice_name_;
 

--- a/diagnostic_aggregator/src/generic_analyzer.cpp
+++ b/diagnostic_aggregator/src/generic_analyzer.cpp
@@ -55,11 +55,11 @@ bool GenericAnalyzer::init(const string base_path, const ros::NodeHandle &n)
     return false;
   }
 
-  XmlRpc::XmlRpcValue findRemove;
-  if (n.getParam("find_and_remove_prefix", findRemove))
+  XmlRpc::XmlRpcValue find_remove;
+  if (n.getParam("find_and_remove_prefix", find_remove))
   {
     vector<string> output;
-    getParamVals(findRemove, output);
+    getParamVals(find_remove, output);
     chaff_ = output;
     startswith_ = output;
   }


### PR DESCRIPTION
Trying to use the `base_path` parameter (as indicated in the wiki) has the following result:

```
base_path: A -> /A//<analyzer-x>
```

which is a path that's not categorized by the robot monitor.

Now the aggregator works with any combination of the `base_path` and `path` parameters.