### PR TITLE
[Aggregator] Fixes C++ Warnings (pluginlib)

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/analyzer_group.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/analyzer_group.h
@@ -51,8 +51,8 @@
 #include "XmlRpcValue.h"
 #include "diagnostic_aggregator/analyzer.h"
 #include "diagnostic_aggregator/status_item.h"
-#include "pluginlib/class_loader.h"
-#include "pluginlib/class_list_macros.h"
+#include "pluginlib/class_loader.hpp"
+#include "pluginlib/class_list_macros.hpp"
 
 namespace diagnostic_aggregator {
 

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer.h
@@ -46,7 +46,7 @@
 #include <sstream>
 #include <boost/shared_ptr.hpp>
 #include <boost/regex.hpp>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "diagnostic_msgs/DiagnosticStatus.h"
 #include "diagnostic_msgs/KeyValue.h"
 #include "diagnostic_aggregator/analyzer.h"

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
@@ -44,7 +44,7 @@
 #include <sstream>
 #include <boost/shared_ptr.hpp>
 #include <boost/regex.hpp>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "diagnostic_msgs/DiagnosticStatus.h"
 #include "diagnostic_msgs/KeyValue.h"
 #include "diagnostic_aggregator/analyzer.h"


### PR DESCRIPTION
This fixes the following warnings:

```
warning: Including header <pluginlib/class_list_macros.h>
 is deprecated,include <pluginlib/class_list_macros.hpp> instead. [-Wcpp]

warning: Including header <pluginlib/class_loader.h>
 is deprecated, include <pluginlib/class_loader.hpp> instead. [-Wcpp]
```

The .hpp files have been backported to indigo

But just a few hours ago they've reverted the deprecation warnings (for now)
See:
ros/pluginlib/pull/70 ( https://github.com/ros/pluginlib/pull/70#issuecomment-379435585) 
ros/pluginlib/pull/115