### PR TITLE
Make FrequencyStatus' name configurable

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -124,6 +124,17 @@ namespace diagnostic_updater
     }
 
       /**
+       * \brief Constructs a FrequencyStatus class with the given parameters.
+       */
+
+      FrequencyStatus(const FrequencyStatusParam &params, const std::string name) :
+        DiagnosticTask(name), params_(params),
+        times_(params_.window_size_), seq_nums_(params_.window_size_)
+    {
+      clear();
+    }
+
+      /**
        * \brief Resets the statistics.
        */
 


### PR DESCRIPTION
I think this is pretty self-explanatory. In some cases you'd like to give the frequency status some other name. This ought to be supported.