### PR TITLE
/diagnostic_updater/DiagnosticTaskVector: added virtual destructor

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.h
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.h
@@ -240,7 +240,8 @@ namespace diagnostic_updater
         return tasks_;
       }
 
-    public:    
+    public:
+      virtual ~DiagnosticTaskVector() {}
       /**
        * \brief Add a DiagnosticTask embodied by a name and function to the
        * DiagnosticTaskVector


### PR DESCRIPTION
This fixes a 'has virtual functions and accessible non-virtual destructor'-warning.