### PR TITLE
update CMakeLists.txt to search for local gtest first

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -20,7 +20,11 @@ if( (${diagnostic_msgs_VERSION} VERSION_EQUAL "1.12.0") OR
 endif()
 
 find_package(Boost REQUIRED COMPONENTS system)
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} gtest-1.7.0/include)
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+
+set(LOCAL_GTEST_DIR "gtest-1.7.0")
+# gtest could be included in ${catkin_INCLUDE_DIRS}, prepend local gtest include directory so it's searched first
+include_directories(BEFORE ${LOCAL_GTEST_DIR}/include)
 
 add_library(${PROJECT_NAME}
   src/status_item.cpp
@@ -41,8 +45,7 @@ target_link_libraries(aggregator_node ${catkin_LIBRARIES}
 )
 
 # Analyzer loader allows other users to test that Analyzers load
-add_executable(analyzer_loader test/analyzer_loader.cpp
-                               gtest-1.7.0/gtest-all.cc)
+add_executable(analyzer_loader test/analyzer_loader.cpp ${LOCAL_GTEST_DIR}/gtest-all.cc)
 target_link_libraries(analyzer_loader diagnostic_aggregator)
 
 if(CATKIN_ENABLE_TESTING)

--- a/diagnostic_aggregator/test/analyzer_loader.cpp
+++ b/diagnostic_aggregator/test/analyzer_loader.cpp
@@ -40,7 +40,7 @@
 #include <diagnostic_aggregator/analyzer_group.h>
 #include <ros/ros.h>
 #include <string>
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 //using namespace std;
 //using namespace diagnostic_aggregator;


### PR DESCRIPTION
gtest `1.7.0` on Windows causes the following error:
```
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(1374): error C2011: 'testing::internal::AutoHandle': 'class' type redefinition
C:\opt\rosdeps\x64\include\gtest/internal/gtest-port.h(1511): note: see declaration of 'testing::internal::AutoHandle'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(3381): error C2440: 'delete': cannot convert from 'const testing::internal::scoped_ptr<testing::internal::GTestFlagSaver>' to 'void*'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(3381): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(3667): error C2511: 'testing::TestInfo::TestInfo(const std::string &,const std::string &,const char *,const char *,testing::internal::TypeId,testing::internal::TestFactoryBase *)': overloaded member function not found in 'testing::TestInfo'
C:\opt\rosdeps\x64\include\gtest/gtest.h(644): note: see declaration of 'testing::TestInfo'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(3676): error C2550: 'testing::TestInfo::{ctor}': constructor initializer lists are only allowed on constructor definitions
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(3710): error C2661: 'testing::TestInfo::TestInfo': no overloaded function takes 6 arguments
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(3709): error C2789: 'test_info': an object of const-qualified type must be initialized
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(3709): note: see declaration of 'test_info'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(7120): error C2079: 'testing::internal::WindowsDeathTest::write_handle_' uses undefined class 'testing::internal::AutoHandle'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(7122): error C2079: 'testing::internal::WindowsDeathTest::child_handle_' uses undefined class 'testing::internal::AutoHandle'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(7127): error C2079: 'testing::internal::WindowsDeathTest::event_handle_' uses undefined class 'testing::internal::AutoHandle'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(7222): error C2672: 'testing::internal::StreamableToString': no matching overloaded function found
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(7728): error C2079: 'parent_process_handle' uses undefined class 'testing::internal::AutoHandle'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(7728): error C2440: 'initializing': cannot convert from 'HANDLE' to 'int'
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(7728): note: There is no context in which this conversion is possible
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(9553): error C2065: 'defined_test_names_': undeclared identifier
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(9554): error C2065: 'defined_test_names_': undeclared identifier
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(9570): error C2065: 'defined_test_names_': undeclared identifier
C:\ros\catkin_ws\upstream\ros-desktop\src\diagnostics\diagnostic_aggregator\gtest-1.7.0\gtest-all.cc(9571): error C2065: 'defined_test_names_': undeclared identifier
NMAKE : fatal error U1077: 'C:\PROGRA~2\MIB055~1\Preview\ENTERP~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\cl.exe' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\Preview\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\Preview\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
```

since a lot of ROS projects use gtest for testing, and gtest is already in a stable `1.8.x` state, change to use global gtest and delete local gtest binaries