### PR TITLE
fix windows build issue

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -124,17 +124,6 @@ namespace diagnostic_updater
     }
 
       /**
-       * \brief Constructs a FrequencyStatus class with the given parameters.
-       */
-
-      FrequencyStatus(const FrequencyStatusParam &params, const std::string name) :
-        DiagnosticTask(name), params_(params),
-        times_(params_.window_size_), seq_nums_(params_.window_size_)
-    {
-      clear();
-    }
-
-      /**
        * \brief Resets the statistics.
        */
 
@@ -201,7 +190,7 @@ namespace diagnostic_updater
         if (*params_.min_freq_ > 0)
           stat.addf("Minimum acceptable frequency (Hz)", "%f",
               *params_.min_freq_ * (1 - params_.tolerance_));
-        if (finite(*params_.max_freq_))
+        if (_finite(*params_.max_freq_))
           stat.addf("Maximum acceptable frequency (Hz)", "%f",
               *params_.max_freq_ * (1 + params_.tolerance_));
       }

--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -124,6 +124,17 @@ namespace diagnostic_updater
     }
 
       /**
+       * \brief Constructs a FrequencyStatus class with the given parameters.	
+       */
+
+       FrequencyStatus(const FrequencyStatusParam &params, const std::string name) :
+        DiagnosticTask(name), params_(params),
+        times_(params_.window_size_), seq_nums_(params_.window_size_)
+    {
+      clear();
+    }
+
+      /**
        * \brief Resets the statistics.
        */
 
@@ -190,7 +201,12 @@ namespace diagnostic_updater
         if (*params_.min_freq_ > 0)
           stat.addf("Minimum acceptable frequency (Hz)", "%f",
               *params_.min_freq_ * (1 - params_.tolerance_));
-        if (_finite(*params_.max_freq_))
+
+#ifdef _WIN32
+        if (isfinite(*params_.max_freq_))
+#else
+        if (finite(*params_.max_freq_))
+#endif
           stat.addf("Maximum acceptable frequency (Hz)", "%f",
               *params_.max_freq_ * (1 + params_.tolerance_));
       }

--- a/diagnostic_updater/src/example.cpp
+++ b/diagnostic_updater/src/example.cpp
@@ -35,6 +35,8 @@
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <std_msgs/Bool.h>
 #include <diagnostic_updater/publisher.h>
+
+// ERROR defined in windows.h causes name collision, undefine the macro to fix the issue
 #ifdef ERROR
 #undef ERROR
 #endif

--- a/diagnostic_updater/src/example.cpp
+++ b/diagnostic_updater/src/example.cpp
@@ -35,6 +35,9 @@
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <std_msgs/Bool.h>
 #include <diagnostic_updater/publisher.h>
+#ifdef ERROR
+#undef ERROR
+#endif
 
 double time_to_launch;
 


### PR DESCRIPTION
[`finite`](https://linux.die.net/man/3/finite) is Linux-only, it's [`_finite`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/finite-finitef?view=vs-2017) on Windows
to work around this, use [`isfinite`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/finite-finitef?view=vs-2017) on Windows, this also seems to exist on Linux (https://linux.die.net/man/3/isfinite)

`ERROR` is defined in windows.h, need to undefine the macro to fix build failure