### PR TITLE
Fix discard_stale (Closes #65)

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -54,6 +54,8 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/launch/test_loader.launch)
   add_rostest(test/launch/test_expected_stale.launch)
   add_rostest(test/launch/test_multiple_match.launch)
+
+  add_rostest(test/launch/test_discard_stale_not_published.launch)
 endif()
 
 catkin_install_python(

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
@@ -90,7 +90,7 @@ public:
     nice_name_ = nice_name;
     path_ = path;
     discard_stale_ = discard_stale;
-    last_header_stale_ = ros::Time::now();
+    last_header_status_change_ = ros::Time::now();
     last_header_level_ = 0;
 
     if (discard_stale_ && timeout <= 0)
@@ -191,11 +191,7 @@ public:
     
     // Header is not stale unless all subs are
     if (all_stale)
-    {
-      if (last_header_level_ != 3)
-        last_header_stale_ = ros::Time::now();
       header_status->level = 3;
-    }
     else if (header_status->level == 3)
       header_status->level = 2;
     
@@ -223,16 +219,21 @@ public:
     }
     
     bool header_stale_timed_out = false;
-    if (timeout_ > 0)
-        header_stale_timed_out = (ros::Time::now() - last_header_stale_).toSec() > timeout_;
+    if (timeout_ > 0 && last_header_level_ == 3)
+        header_stale_timed_out = (ros::Time::now() - last_header_status_change_).toSec() > timeout_;
+
+    if (last_header_level_ != header_status->level)
+    {
+      last_header_status_change_ = ros::Time::now();
+      last_header_level_ = header_status->level; // update the last header level
+    }
 
     if (discard_stale_ && processed.size() == 1 && header_stale_timed_out)
     {
       std::vector<boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> > vec;
       return vec;
     }
-
-    last_header_level_ = processed[0]->level; // update the last header level
+    
     return processed;
   }
 
@@ -254,6 +255,7 @@ public:
 protected:
   std::string nice_name_;
   std::string path_;
+
   double timeout_;
   int num_items_expected_;
 
@@ -269,7 +271,7 @@ private:
   std::map<std::string, boost::shared_ptr<StatusItem> > items_;
 
   bool discard_stale_, has_initialized_, has_warned_;
-  ros::Time last_header_stale_; // last timestamp at which the header of the returned diagnostic msg array turned stale
+  ros::Time last_header_status_change_; // last timestamp at which the header of the returned diagnostic msg array changed
   int last_header_level_; // last level reported by the header of the returend diagnostic msg array
 
 };

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.h
@@ -90,6 +90,8 @@ public:
     nice_name_ = nice_name;
     path_ = path;
     discard_stale_ = discard_stale;
+    last_header_stale_ = ros::Time::now();
+    last_header_level_ = 0;
 
     if (discard_stale_ && timeout <= 0)
     {
@@ -189,7 +191,11 @@ public:
     
     // Header is not stale unless all subs are
     if (all_stale)
+    {
+      if (last_header_level_ != 3)
+        last_header_stale_ = ros::Time::now();
       header_status->level = 3;
+    }
     else if (header_status->level == 3)
       header_status->level = 2;
     
@@ -216,6 +222,17 @@ public:
         header_status->message = "No items found, expected " + expec.str();
     }
     
+    bool header_stale_timed_out = false;
+    if (timeout_ > 0)
+        header_stale_timed_out = (ros::Time::now() - last_header_stale_).toSec() > timeout_;
+
+    if (discard_stale_ && processed.size() == 1 && header_stale_timed_out)
+    {
+      std::vector<boost::shared_ptr<diagnostic_msgs::DiagnosticStatus> > vec;
+      return vec;
+    }
+
+    last_header_level_ = processed[0]->level; // update the last header level
     return processed;
   }
 
@@ -237,7 +254,6 @@ public:
 protected:
   std::string nice_name_;
   std::string path_;
-
   double timeout_;
   int num_items_expected_;
 
@@ -253,6 +269,9 @@ private:
   std::map<std::string, boost::shared_ptr<StatusItem> > items_;
 
   bool discard_stale_, has_initialized_, has_warned_;
+  ros::Time last_header_stale_; // last timestamp at which the header of the returned diagnostic msg array turned stale
+  int last_header_level_; // last level reported by the header of the returend diagnostic msg array
+
 };
 
 }

--- a/diagnostic_aggregator/test/discard_stale_not_published_analyzers.yaml
+++ b/diagnostic_aggregator/test/discard_stale_not_published_analyzers.yaml
@@ -1,0 +1,11 @@
+analyzers:
+  my_stale_item:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: Nonexistent1
+    find_and_remove_prefix: 'nonexistent1'
+  my_stale_item_that_should_be_ignored:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: Nonexistent2
+    find_and_remove_prefix: 'nonexistent2'
+    discard_stale: true
+    timeout: 5.0

--- a/diagnostic_aggregator/test/discard_stale_not_published_analyzers.yaml
+++ b/diagnostic_aggregator/test/discard_stale_not_published_analyzers.yaml
@@ -1,8 +1,4 @@
 analyzers:
-  my_stale_item:
-    type: diagnostic_aggregator/GenericAnalyzer
-    path: Nonexistent1
-    find_and_remove_prefix: 'nonexistent1'
   my_stale_item_that_should_be_ignored:
     type: diagnostic_aggregator/GenericAnalyzer
     path: Nonexistent2

--- a/diagnostic_aggregator/test/discard_stale_not_published_pub.py
+++ b/diagnostic_aggregator/test/discard_stale_not_published_pub.py
@@ -52,10 +52,9 @@ if __name__ == '__main__':
         array = DiagnosticArray()
         array.header.stamp = rospy.get_rostime()
 
-        if rospy.get_time() - start_time < 5:
-            array.status = [
-                DiagnosticStatus(0, 'Nonexistent1', 'OK', '', []),
-                DiagnosticStatus(1, 'Nonexistent2', 'WARN', '', [])]
+        # after 2 seconds we will publish only an empty diagnostics
+        if rospy.get_time() - start_time < 3:
+            array.status = [DiagnosticStatus(1, 'nonexistent2', 'WARN', '', [])]
 
         pub.publish(array)
-        sleep(1)
+        sleep(1.0)

--- a/diagnostic_aggregator/test/discard_stale_not_published_pub.py
+++ b/diagnostic_aggregator/test/discard_stale_not_published_pub.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2019, Magazino GmbH.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Magazino GmbH nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# \author Guglielmo Gemignani
+
+# \brief Publishes messages for aggregator testing of discard stale flag
+
+from time import sleep
+
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
+import rospy
+
+
+if __name__ == '__main__':
+    rospy.init_node('diag_pub')
+    pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=10)
+
+    start_time = rospy.get_time()
+
+    while not rospy.is_shutdown():
+        array = DiagnosticArray()
+        array.header.stamp = rospy.get_rostime()
+
+        if rospy.get_time() - start_time < 5:
+            array.status = [
+                DiagnosticStatus(0, 'Nonexistent1', 'OK', '', []),
+                DiagnosticStatus(1, 'Nonexistent2', 'WARN', '', [])]
+
+        pub.publish(array)
+        sleep(1)

--- a/diagnostic_aggregator/test/discard_stale_not_published_test.py
+++ b/diagnostic_aggregator/test/discard_stale_not_published_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2009, Willow Garage, Inc.
+# Copyright (c) 2019, Magazino GmbH.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
 #    copyright notice, this list of conditions and the following
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
-#  * Neither the name of the Willow Garage nor the names of its
+#  * Neither the name of Magazino GmbH nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -36,10 +36,6 @@
 
 ##\brief Tests that expected items from GenericAnalyzer will be removed after the timeout if discard_stale is set to true
 
-DURATION = 10
-PKG = 'diagnostic_aggregator'
-
-import roslib; roslib.load_manifest(PKG)
 import rospy, rostest, unittest
 from diagnostic_msgs.msg import DiagnosticArray
 from time import sleep
@@ -66,9 +62,10 @@ class TestDiscardStale(unittest.TestCase):
                 self._agg_expecteds.append(stat)
 
     def test_discard_stale(self):
+        duration = 10
         while not rospy.is_shutdown():
             sleep(1.0)
-            if rospy.Time.now() - self._start_time > rospy.Duration(DURATION):
+            if rospy.Time.now() - self._start_time > rospy.Duration(duration):
                 break
 
         with self._mutex:
@@ -80,4 +77,4 @@ class TestDiscardStale(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    rostest.run(PKG, sys.argv[0], TestDiscardStale, sys.argv)
+    rostest.run('diagnostic_aggregator', sys.argv[0], TestDiscardStale, sys.argv)

--- a/diagnostic_aggregator/test/discard_stale_not_published_test.py
+++ b/diagnostic_aggregator/test/discard_stale_not_published_test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2009, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+##\author Guglielmo Gemignani
+
+##\brief Tests that expected items from GenericAnalyzer will be removed after the timeout if discard_stale is set to true
+
+DURATION = 10
+PKG = 'diagnostic_aggregator'
+
+import roslib; roslib.load_manifest(PKG)
+import rospy, rostest, unittest
+from diagnostic_msgs.msg import DiagnosticArray
+from time import sleep
+import sys
+import threading
+
+
+class TestDiscardStale(unittest.TestCase):
+    def __init__(self, *args):
+        super(TestDiscardStale, self).__init__(*args)
+
+        self._mutex = threading.Lock()
+
+        self._agg_expecteds = []
+        
+        rospy.init_node('test_expected_stale')        
+        sub_agg = rospy.Subscriber("/diagnostics_agg", DiagnosticArray, self.diag_agg_cb)
+        self._start_time = rospy.Time.now()
+
+    def diag_agg_cb(self, msg):
+        with self._mutex:
+            self._agg_expecteds = []
+            for stat in msg.status:
+                self._agg_expecteds.append(stat)
+
+    def test_discard_stale(self):
+        while not rospy.is_shutdown():
+            sleep(1.0)
+            if rospy.Time.now() - self._start_time > rospy.Duration(DURATION):
+                break
+
+        with self._mutex:
+            self.assert_(len(self._agg_expecteds) == 1,
+                         "There should only be one expected aggregated item left, {} found instead!".
+                         format(len(self._agg_expecteds)))
+            self.assert_(self._agg_expecteds[0].name == "/Nonexistent1",
+                         "The name of the only aggregate message should be '/Nonexistent1'!")
+
+
+if __name__ == '__main__':
+    rostest.run(PKG, sys.argv[0], TestDiscardStale, sys.argv)

--- a/diagnostic_aggregator/test/launch/test_discard_stale_not_published.launch
+++ b/diagnostic_aggregator/test/launch/test_discard_stale_not_published.launch
@@ -1,0 +1,11 @@
+<launch>
+  <node pkg="diagnostic_aggregator" type="aggregator_node"
+        name="diag_agg" output="screen" >
+    <rosparam command="load" 
+              file="$(find diagnostic_aggregator)/test/discard_stale_not_published_analyzers.yaml" />
+  </node>
+
+  <test pkg="diagnostic_aggregator" type="discard_stale_not_published_test.py"
+        name="discard_stale_not_published_tester"
+        test-name="discard_stale_not_published_test" />
+</launch>

--- a/diagnostic_aggregator/test/launch/test_discard_stale_not_published.launch
+++ b/diagnostic_aggregator/test/launch/test_discard_stale_not_published.launch
@@ -5,6 +5,9 @@
               file="$(find diagnostic_aggregator)/test/discard_stale_not_published_analyzers.yaml" />
   </node>
 
+  <node pkg="diagnostic_aggregator" type="discard_stale_not_published_pub.py"
+        name="diag_pub" />
+
   <test pkg="diagnostic_aggregator" type="discard_stale_not_published_test.py"
         name="discard_stale_not_published_tester"
         test-name="discard_stale_not_published_test" />


### PR DESCRIPTION
Make sure that analyzers flagged with discard_stale = true are correctly
removed after being stale for a period greater than the timeout
