### PR TITLE
Install newer dpkg for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
+  - sudo apt-get install dkpg
   - sudo apt-get install python-catkin-pkg python-rosdep ros-indigo-catkin
   - sudo `which rosdep` init
   - rosdep update


### PR DESCRIPTION
Install a newer version of dpkg to work around upstream ROS packaging issue.