### PR TITLE
Fix httplib import for Python 3.

### DIFF
--- a/diagnostic_updater/src/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/src/diagnostic_updater/_diagnostic_updater.py
@@ -37,8 +37,13 @@
 """
 
 import rospy
-import threading, httplib
+import threading
 from diagnostic_msgs.msg import DiagnosticArray
+
+try:
+    import httplib
+except ImportError:
+    import http.client as httplib
 
 from ._diagnostic_status_wrapper import *
 


### PR DESCRIPTION
Per the official docs:

> The `httplib` module has been renamed to http.client in Python 3. The 2to3 tool will automatically adapt imports when converting your sources to Python 3.

https://docs.python.org/2/library/httplib.html#module-httplib