### PR TITLE
Resolve div by zero in updater

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -172,7 +172,6 @@ namespace diagnostic_updater
         int events = curseq - seq_nums_[hist_indx_];
         double window = (curtime - times_[hist_indx_]).toSec();
 
-        // If the time window is 0, we cannot truthfully report any frequency
         if (window != 0)
         {
             double freq = events / window;


### PR DESCRIPTION
This resolves https://github.com/ros/diagnostics/issues/92. When the time window is 0 the program fails due to division by 0. With this change, division by 0 will not occur and instead the frequency will be omitted from the stats.