### PR TITLE
Re-add leading character to node name

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -578,8 +578,7 @@ private:
       status_vec.begin();
       iter != status_vec.end(); iter++)
     {
-      // see https://github.com/ros/diagnostics/pull/109
-      iter->name = node_name_.substr(1) + std::string(": ") + iter->name;
+      iter->name = node_name_ + std::string(": ") + iter->name;
     }
     diagnostic_msgs::msg::DiagnosticArray msg;
     msg.status = status_vec;


### PR DESCRIPTION
The ROS 2 API is giving us the node name without a leading slash.