### PR TITLE
Use std::isfinite due to deprecation on osx

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -203,11 +203,7 @@ namespace diagnostic_updater
           stat.addf("Minimum acceptable frequency (Hz)", "%f",
               *params_.min_freq_ * (1 - params_.tolerance_));
 
-#ifdef _WIN32
-        if (isfinite(*params_.max_freq_))
-#else
-        if (finite(*params_.max_freq_))
-#endif
+        if (std::isfinite(*params_.max_freq_))
           stat.addf("Maximum acceptable frequency (Hz)", "%f",
               *params_.max_freq_ * (1 + params_.tolerance_));
       }


### PR DESCRIPTION
On osx the c function finite is deprecated resulting in a build failure because clang fails on deprecated functions by default.

std::isfinite is in C++11 so the specific hadling for windows can be removed here as well.