### PR TITLE
Remove extra (not needed) trailing ':'

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -380,13 +380,13 @@ namespace diagnostic_updater
           }
         }
 
-        stat.addf("Earliest timestamp delay:", "%f", min_delta_);
-        stat.addf("Latest timestamp delay:", "%f", max_delta_);
-        stat.addf("Earliest acceptable timestamp delay:", "%f", params_.min_acceptable_);
-        stat.addf("Latest acceptable timestamp delay:", "%f", params_.max_acceptable_);
-        stat.add("Late diagnostic update count:", late_count_);
-        stat.add("Early diagnostic update count:", early_count_);
-        stat.add("Zero seen diagnostic update count:", zero_count_);
+        stat.addf("Earliest timestamp delay", "%f", min_delta_);
+        stat.addf("Latest timestamp delay", "%f", max_delta_);
+        stat.addf("Earliest acceptable timestamp delay", "%f", params_.min_acceptable_);
+        stat.addf("Latest acceptable timestamp delay", "%f", params_.max_acceptable_);
+        stat.add("Late diagnostic update count", late_count_);
+        stat.add("Early diagnostic update count", early_count_);
+        stat.add("Zero seen diagnostic update count", zero_count_);
 
         deltas_valid_ = false;
         min_delta_ = 0;


### PR DESCRIPTION
Without this we get this diagnostics output:

``` bash
[ WARN  ] /node:  topic status - Frequency too high.
    timestamp:   2018-10-15 22:27:31.374786+00:00
    hardware_id: 
    - Events in window: 65
    - Events since startup: 29107
    - Duration of window (s): 5.122087
    - Actual frequency (Hz): 12.690139
    - Target frequency (Hz): 0.000000
    - Minimum acceptable frequency (Hz): 0.000000
    - Maximum acceptable frequency (Hz): 0.000000
    - Earliest timestamp delay:: 0.000000
    - Latest timestamp delay:: 0.000008
    - Earliest acceptable timestamp delay:: -1.000000
    - Latest acceptable timestamp delay:: 5.000000
    - Late diagnostic update count:: 0
    - Early diagnostic update count:: 0
    - Zero seen diagnostic update count:: 0
```

that has `::` for the last 7 entries, instead of just `:`.