### PR TITLE
Make DiagnosticStatusWrapper no longer implicitly copyable

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/DiagnosticStatusWrapper.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/DiagnosticStatusWrapper.hpp
@@ -72,6 +72,16 @@ public:
   {}
 
   /**
+   * \brief Copy constructor
+   * Defined and marked explicit so that you don't accidentally use a
+   * function<void(DiagnosticStatusWrapper)> where a function<void(DiagnosticStatusWrapper &)>
+   * is needed. Otherwise, it's easy to accidentally create a DiagnosticTask that silently does
+   * nothing.
+   * \param other Reference to object to copy
+   */
+  explicit DiagnosticStatusWrapper(const DiagnosticStatusWrapper & other);
+
+  /**
    * \brief Fills out the level and message fields of the DiagnosticStatus.
    *
    * \param lvl Numerical level to assign to this Status (OK, Warn, Err).


### PR DESCRIPTION
Before this, the following code would implicitly copy a `DiagnosticStatusWrapper`, updating the copy and silently discarding it:
```
  updater->add("power", [this](auto t) { update_power_diagnostics(t); });
```
Now, the code will fail with a compile-time error. You will need to change it to something like the following to get it to build:
```
  updater->add("power", [this](auto & t) { update_power_diagnostics(t); });
```
