### PR TITLE
Spin on node in diagnostic_updater example

### DIFF
--- a/diagnostic_updater/src/example.cpp
+++ b/diagnostic_updater/src/example.cpp
@@ -244,6 +244,7 @@ int main(int argc, char ** argv)
     // We can call updater.update whenever is convenient. It will take care
     // of rate-limiting the updates.
     updater.update();
+    rclcpp::spinSome(node);
   }
 
   return 0;

--- a/diagnostic_updater/src/example.cpp
+++ b/diagnostic_updater/src/example.cpp
@@ -244,7 +244,7 @@ int main(int argc, char ** argv)
     // We can call updater.update whenever is convenient. It will take care
     // of rate-limiting the updates.
     updater.update();
-    rclcpp::spinSome(node);
+    rclcpp::spin_some(node);
   }
 
   return 0;


### PR DESCRIPTION
This will allow manipulation and query of the parameters. Without this change, invoking `ros2 param list` hangs.