### PR TITLE
ROS2: Parameter description hotfix

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -393,7 +393,7 @@ public:
     warn_nohwid_done_(false)
   {
     double period = parameters_interface->declare_parameter(
-      "diagnostic_updater.period", rclcpp::ParameterValue(1.0)).get<double>();
+      "diagnostic_updater.period", rclcpp::ParameterValue(1.0), rcl_interfaces::msg::ParameterDescriptor()).get<double>();
     period_ = static_cast<rcl_duration_value_t>(period * 1e9);
     next_time_ = rclcpp::Clock().now() + rclcpp::Duration(period_);
   }

--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -393,7 +393,8 @@ public:
     warn_nohwid_done_(false)
   {
     double period = parameters_interface->declare_parameter(
-      "diagnostic_updater.period", rclcpp::ParameterValue(1.0), rcl_interfaces::msg::ParameterDescriptor()).get<double>();
+      "diagnostic_updater.period",
+      rclcpp::ParameterValue(1.0), rcl_interfaces::msg::ParameterDescriptor()).get<double>();
     period_ = static_cast<rcl_duration_value_t>(period * 1e9);
     next_time_ = rclcpp::Clock().now() + rclcpp::Duration(period_);
   }


### PR DESCRIPTION
Couldn't compile in dashing because declare_parameter needed 3 arguments, haven't seen that before, but it seems the parameter_interface does not have a default value for ParameterDescription.

edit: fails because it runs on crystal, some of these changes are dashing-specific.