### PR TITLE
Extend initial connect timeout for add_analyzers

### DIFF
--- a/diagnostic_aggregator/scripts/add_analyzers
+++ b/diagnostic_aggregator/scripts/add_analyzers
@@ -48,6 +48,7 @@ class AddAnalyzers:
         self.bond = bondpy.Bond("/diagnostics_agg/bond" + self.namespace,
                                 self.namespace,
                                 on_broken=self.bond_broken)
+        self.bond.set_connect_timeout(rospy.Duration(120))
 
         try:
             rospy.wait_for_service('/diagnostics_agg/add_diagnostics', timeout=args.timeout)


### PR DESCRIPTION
Our situation was launching a diag_agg instance in a resource-contrained VM environment where it was hit on startup with 5+ `add_analyzers` instances. The service would come available and return, with bonds being established and timing out on the `add_analyzers` side before the aggregator could begin publishing.

I don't feel it's worth the bother of parameterizing this— I see no scenario where you'd want it to be anything other than "really long". An alternative approach to this could be to use the "broken" callback as a chance to basically start over with re-registering the analyzers. This would allow the diag_agg node to restart and eventually find its way back to the proper state, whereas right now that would break all the bonds and the add_analyzers would simply exit.