### PR TITLE
Fix DiagnosedPublisher

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -46,6 +46,26 @@
 #include "rclcpp/publisher.hpp"
 #include "rclcpp/subscription.hpp"
 
+namespace
+{
+/**
+ * \brief Helper struct to check message for header member.
+ */
+template<typename T, typename = void>
+struct has_header : public std::false_type
+{};
+
+/**
+ * \brief Helper struct to check message for header member.
+ */
+template<typename T>
+struct has_header<T,
+  typename std::enable_if<std::is_same<std_msgs::msg::Header,
+  decltype(std::declval<T>().header)>::value>::type>
+  : public std::true_type
+{};
+}  // namespace
+
 namespace diagnostic_updater
 {
 
@@ -199,7 +219,10 @@ public:
     const diagnostic_updater::FrequencyStatusParam & freq,
     const diagnostic_updater::TimeStampStatusParam & stamp)
   : TopicDiagnostic(pub->get_topic_name(), diag, freq, stamp),
-    publisher_(pub) {}
+    publisher_(pub)
+  {
+    static_assert(has_header<MessageT>::value, "Message type has to have a header.");
+  }
 
   virtual ~DiagnosedPublisher() {}
 

--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -38,6 +38,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_updater/update_functions.hpp"

--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -171,7 +171,7 @@ private:
  * the TopicDiagnostic to be combined for added convenience.
  */
 
-template<class T>
+template<typename MessageT, typename AllocatorT = std::allocator<void>>
 class DiagnosedPublisher : public TopicDiagnostic
 {
 public:
@@ -190,9 +190,10 @@ public:
    * computing statistics.
    */
 
+  using PublisherT = rclcpp::Publisher<MessageT, AllocatorT>;
+
   DiagnosedPublisher(
-    const rclcpp::Publisher<
-      diagnostic_msgs::msg::DiagnosticArray>::SharedPtr & pub,
+    const typename PublisherT::SharedPtr & pub,
     diagnostic_updater::Updater & diag,
     const diagnostic_updater::FrequencyStatusParam & freq,
     const diagnostic_updater::TimeStampStatusParam & stamp)
@@ -207,10 +208,10 @@ public:
    * The timestamp to be used by the TimeStampStatus class will be
    * extracted from message.header.stamp.
    */
-  virtual void publish(const std::shared_ptr<T> & message)
+  virtual void publish(typename PublisherT::MessageUniquePtr message)
   {
     tick(message->header.stamp);
-    publisher_->publish(message);
+    publisher_->publish(std::move(message));
   }
 
   /**
@@ -219,7 +220,7 @@ public:
    * The timestamp to be used by the TimeStampStatus class will be
    * extracted from message.header.stamp.
    */
-  virtual void publish(const T & message)
+  virtual void publish(const MessageT & message)
   {
     tick(message.header.stamp);
     publisher_->publish(message);
@@ -228,7 +229,7 @@ public:
   /**
    * \brief Returns the publisher.
    */
-  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr
+  typename PublisherT::SharedPtr
   getPublisher() const
   {
     return publisher_;
@@ -237,14 +238,13 @@ public:
   /**
    * \brief Changes the publisher.
    */
-  void setPublisher(
-    rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub)
+  void setPublisher(typename PublisherT::SharedPtr pub)
   {
     publisher_ = pub;
   }
 
 private:
-  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr publisher_;
+  typename PublisherT::SharedPtr publisher_;
 };
 }   // namespace diagnostic_updater
 


### PR DESCRIPTION
The DiagnosedPublisher should be a wrapper around a publisher for any type of message, but it could only be used with publishers for DiagnosticArray messages. This was fixed.