### PR TITLE
noetic release

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -1,5 +1,5 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(diagnostic_aggregator)
 
 # Load catkin and all dependencies required for this package

--- a/diagnostic_aggregator/test/add_analyzers_test.py
+++ b/diagnostic_aggregator/test/add_analyzers_test.py
@@ -51,7 +51,7 @@ class TestAddAnalyzer(unittest.TestCase):
         self.namespace = rospy.get_name()
         paramlist = rosparam.load_file(rospy.myargv()[1])
         # expect to receive these paths in the added analyzers
-        self.expected = [paramlist[0][1] + analyzer['path'] for name, analyzer in paramlist[0][0]['analyzers'].iteritems()]
+        self.expected = [paramlist[0][1] + analyzer['path'] for name, analyzer in paramlist[0][0]['analyzers'].items()]
 
         self._mutex = threading.Lock()
         self.agg_msgs = {}
@@ -90,7 +90,7 @@ class TestAddAnalyzer(unittest.TestCase):
 
         # confirm that the things we're going to add aren't there already
         with self._mutex:
-            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+            agg_paths = [msg.name for name, msg in self.agg_msgs.items()]
             self.assert_(not any(expected in agg_paths for expected in self.expected))
             
         # add the new groups
@@ -108,7 +108,7 @@ class TestAddAnalyzer(unittest.TestCase):
         # the paths are probably still in the 'Other' group because the bond
         # hasn't been fully formed
         with self._mutex:
-            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+            agg_paths = [msg.name for name, msg in self.agg_msgs.items()]
             self.assert_(all(expected in agg_paths for expected in self.expected))
 
         rospy.sleep(rospy.Duration(5)) # wait a bit for the new items to move to the right group
@@ -116,11 +116,11 @@ class TestAddAnalyzer(unittest.TestCase):
         self.pub.publish(arr) # publish again to get the correct groups to show OK
         self.wait_for_agg()
 
-        for name, msg in self.agg_msgs.iteritems():
+        for name, msg in self.agg_msgs.items():
             if name in self.expected: # should have just received messages on the analyzer
                 self.assert_(msg.message == 'OK')
                 
-            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+            agg_paths = [msg.name for name, msg in self.agg_msgs.items()]
             self.assert_(all(expected in agg_paths for expected in self.expected))
                 
 
@@ -129,7 +129,7 @@ class TestAddAnalyzer(unittest.TestCase):
         self.wait_for_agg()
         # the aggregator data should no longer contain the paths once the bond is shut down
         with self._mutex:
-            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+            agg_paths = [msg.name for name, msg in self.agg_msgs.items()]
             self.assert_(not any(expected in agg_paths for expected in self.expected))
         
 if __name__ == '__main__':

--- a/diagnostic_aggregator/test/add_analyzers_test.py
+++ b/diagnostic_aggregator/test/add_analyzers_test.py
@@ -133,5 +133,5 @@ class TestAddAnalyzer(unittest.TestCase):
             self.assert_(not any(expected in agg_paths for expected in self.expected))
         
 if __name__ == '__main__':
-    print 'SYS ARGS:', sys.argv
+    print('SYS ARGS:', sys.argv)
     rostest.run(PKG, sys.argv[0], TestAddAnalyzer, sys.argv)

--- a/diagnostic_aggregator/test/aggregator_test.py
+++ b/diagnostic_aggregator/test/aggregator_test.py
@@ -163,8 +163,8 @@ class TestAggregator(unittest.TestCase):
         super(TestAggregator, self).__init__(*args)
         parser = OptionParser(usage="./%prog [options]", prog="aggregator_test.py")
         parser.add_option('--gtest_output', action="store", dest="gtest")
-        parser.add_option('--param_name', action="store", dest="param", 
-                          default='diag_agg', metavar="PARAM_NAME", 
+        parser.add_option('--param_name', action="store", dest="param",
+                          default='diag_agg', metavar="PARAM_NAME",
                           help="Name of parameter that defines analyzers")
         parser.add_option('--duration', action="store", dest="duration",
                           default=10, metavar="DURATIION",
@@ -258,5 +258,5 @@ class TestAggregator(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print 'SYS ARGS:', sys.argv
+    print('SYS ARGS:', sys.argv)
     rostest.run(PKG, sys.argv[0], TestAggregator, sys.argv)

--- a/diagnostic_aggregator/test/expected_stale_test.py
+++ b/diagnostic_aggregator/test/expected_stale_test.py
@@ -75,7 +75,7 @@ class TestExpectedItemsStale(unittest.TestCase):
         self._expecteds = {}
         self._agg_expecteds = {}
 
-        rospy.init_node('test_expected_stale')        
+        rospy.init_node('test_expected_stale')
         self._starttime = rospy.get_time()
 
         sub = rospy.Subscriber("/diagnostics", DiagnosticArray, self.diag_cb)
@@ -102,8 +102,8 @@ class TestExpectedItemsStale(unittest.TestCase):
         with self._mutex:
             self.assert_(len(self._expecteds) > 0, "No expected items found in raw data!")
 
-            for name, item in self._expecteds.iteritems():
-                self.assert_(self._agg_expecteds.has_key(name), "Item %s not found in aggregated diagnostics output" % name)
+            for name, item in self._expecteds.items():
+                self.assert_(name in self._agg_expecteds, "Item %s not found in aggregated diagnostics output" % name)
                 if item.is_stale():
                     self.assert_(self._agg_expecteds[name].level == 3, "Stale item in diagnostics, but aggregated didn't report as stale. Item: %s, state: %d" %(name, self._agg_expecteds[name].level))
                 else:

--- a/diagnostic_aggregator/test/multiple_match_test.py
+++ b/diagnostic_aggregator/test/multiple_match_test.py
@@ -102,10 +102,10 @@ class TestMultipleMatch(unittest.TestCase):
         self.assert_(not rospy.is_shutdown(), "Rospy shutdown!")
 
         with self._mutex:
-            self.assert_(self._multi_items.has_key(HEADER1), "Didn't have item under %s. Items: %s" % (HEADER1, self._multi_items))
+            self.assert_(HEADER1 in self._multi_items, "Didn't have item under %s. Items: %s" % (HEADER1, self._multi_items))
             self.assert_(self._multi_items[HEADER1].name == MULTI_NAME, "Item name under %s didn't match %s" % (HEADER1, MULTI_NAME))
 
-            self.assert_(self._multi_items.has_key(HEADER2), "Didn't have item under %s" % HEADER2)
+            self.assert_(HEADER2 in self._multi_items, "Didn't have item under %s" % HEADER2)
             self.assert_(self._multi_items[HEADER2].name == MULTI_NAME, "Item name under %s didn't match %s" % (HEADER2, MULTI_NAME))
          
 

--- a/diagnostic_analysis/CMakeLists.txt
+++ b/diagnostic_analysis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(diagnostic_analysis)
 
 # Load catkin and all dependencies required for this package

--- a/diagnostic_analysis/scripts/export_csv.py
+++ b/diagnostic_analysis/scripts/export_csv.py
@@ -56,22 +56,22 @@ if __name__ == '__main__':
 
     exporters = []
 
-    print 'Output directory: %s/output' % options.directory
+    print('Output directory: %s/output' % options.directory)
 
     try:
         for i, f in enumerate(args):
             filepath = 'output/%s_csv' % os.path.basename(f)[0:os.path.basename(f).find('.')]
             
             output_dir = os.path.join(options.directory,  filepath)
-            print "Processing file %s. File %d of %d." % (os.path.basename(f), i + 1, len(args))
-            
+            print("Processing file %s. File %d of %d." % (os.path.basename(f), i + 1, len(args)))
+
             exp = LogExporter(output_dir, f)
             exp.process_log()
             exp.finish_logfile()
             exporters.append(exp)
 
-        print 'Finished processing files.'
+        print('Finished processing files.')
     except:
         import traceback
-        print "Caught exception processing log file"
+        print("Caught exception processing log file")
         traceback.print_exc()

--- a/diagnostic_analysis/scripts/sparse_csv.py
+++ b/diagnostic_analysis/scripts/sparse_csv.py
@@ -64,15 +64,15 @@ if __name__=='__main__':
 
     # Get CSV file
     if len(args) < 1:
-        print 'No CSV file given.'
+        print('No CSV file given.')
         sys.exit(0)
 
     csv_file = args[0]
 
     if not csv_file.endswith('.csv'):
-        print 'File %s is not a CSV file. Aborting.' % csv_file
-        sys.exit(0)    
-    
+        print('File %s is not a CSV file. Aborting.' % csv_file)
+        sys.exit(0)
+
     if options.max:
         output_file = make_sparse_length(csv_file, 65000)
     elif options.length is None:
@@ -80,4 +80,4 @@ if __name__=='__main__':
     else:
         output_file = make_sparse_length(csv_file, int(options.length))
 
-    print 'Created sparse CSV %s' % output_file
+    print('Created sparse CSV %s' % output_file)

--- a/diagnostic_analysis/setup.py
+++ b/diagnostic_analysis/setup.py
@@ -1,6 +1,6 @@
 ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/diagnostic_analysis/src/diagnostic_analysis/exporter.py
+++ b/diagnostic_analysis/src/diagnostic_analysis/exporter.py
@@ -71,7 +71,7 @@ class LogExporter:
     ##\brief Return filename of output
     ##\param name str : DiagnosticStatus name ex: 'Mechanism Control'
     def get_filename(self, name):
-        if not self._stats.has_key(name):
+        if not name in self._stats:
             return None # self.output_dir + '/%s.csv' % name.replace(' ', '_')
         return self._stats[name]['file_name']
 
@@ -92,7 +92,7 @@ class LogExporter:
         for status in msg.status:
             name = status.name
 
-            if (not self._stats.has_key(name)):
+            if (not name in self._stats):
                 self._stats[name] = {}
                 
                 fields = {}
@@ -114,14 +114,14 @@ class LogExporter:
             # Check to see if fields have changed. Add new fields to map
             if (not [s.key for s in status.values] == self._stats[name]['fields'].keys()):
                 for s in status.values:
-                    if not self._stats[name]['fields'].has_key(s.key):
+                    if not s.key in self._stats[name]['fields']:
                         self._stats[name]['fields'][s.key] = len(self._stats[name]['fields'])
 
             # Add values in correct place for header index
-            # Key/Value pairs can move around, this makes sure values are 
+            # Key/Value pairs can move around, this makes sure values are
             # added to correct keys
             vals = []
-            for key, val in self._stats[name]['fields'].iteritems():
+            for key, val in self._stats[name]['fields'].items():
                 vals.append('')
             for s in status.values:
                 vals[self._stats[name]['fields'][s.key]] = s.value.replace('\n','  ').replace(',',' ')
@@ -129,32 +129,31 @@ class LogExporter:
             msg = status.message.replace(',',' ').strip()
             hw_id = status.hardware_id.replace(',', ' ')
         
-            self._stats[name]['data_file'].write(','.join([time.strftime("%Y/%m/%d %H:%M:%S", t)] + 
+            self._stats[name]['data_file'].write(','.join([time.strftime("%Y/%m/%d %H:%M:%S", t)] +
                                             [str(status.level), msg, hw_id] + vals) + '\n')
 
     ##\brief Close logfile, append data to header
     def finish_logfile(self):
         for name in self._stats:
             # Sort fields by correct index, add to header
-            field_dict = sorted(self._stats[name]['fields'].iteritems(), key=operator.itemgetter(1))
+            field_dict = sorted(self._stats[name]['fields'].items(), key=operator.itemgetter(1))
             fields = map(operator.itemgetter(0), field_dict)
             
-            header_line = ','.join(['Timestamp'] + ['Level', 'Message', 'Hardware ID'] + 
+            header_line = ','.join(['Timestamp'] + ['Level', 'Message', 'Hardware ID'] +
                                     [f.replace(',','').replace('\n', ' ') for f in fields]) + '\n'
             
             file_name = os.path.join(self.output_dir, name.replace(' ', '_').replace('(', '').replace(')', '').replace('/', '__').replace('.', '').replace('#', '') + '.csv')
             
-            output_file = file(file_name, 'w')
+            output_file = open(file_name, 'w')
             output_file.write(header_line)
             output_file.close()
 
 
             self._stats[name]['data_file'].close() # Close data
-            
+
             # Append the tmp data file to the header
             subprocess.call("cat %s >> %s" % (self._stats[name]['data_name'], file_name), shell=True)
             # Remove tmp file
             os.remove(self._stats[name]['data_name'])
             # Store filename
             self._stats[name]['file_name'] = file_name
-    

--- a/diagnostic_analysis/src/diagnostic_analysis/exporter.py
+++ b/diagnostic_analysis/src/diagnostic_analysis/exporter.py
@@ -84,7 +84,7 @@ class LogExporter:
     ##\brief Creates and updates data files with new messages
     def _update(self, topic, msg):
         if (not (topic == '/diagnostics')):
-            print "Discarding message on topic: %s" % topic
+            print("Discarding message on topic: %s" % topic)
             return
         
         t = time.localtime(float(str(msg.header.stamp)) / 1000000000.0)

--- a/diagnostic_analysis/src/diagnostic_analysis/sparse.py
+++ b/diagnostic_analysis/src/diagnostic_analysis/sparse.py
@@ -56,7 +56,7 @@ def make_sparse_skip(csv_file, skip):
     skip_count = skip
     for row in input_reader:
         if skip_count == skip:
-            output_writer.writerow([r.encode() for r in row])
+            output_writer.writerow(row)
             skip_count = 0
             
         skip_count = skip_count + 1

--- a/diagnostic_analysis/src/diagnostic_analysis/sparse.py
+++ b/diagnostic_analysis/src/diagnostic_analysis/sparse.py
@@ -48,15 +48,15 @@ import csv, os, sys
 def make_sparse_skip(csv_file, skip):
     output_file = csv_file[:-4] + '_sparse.csv'
 
-    input_reader = csv.reader(open(csv_file, 'rb'))
+    input_reader = csv.reader(open(csv_file, newline=''), delimiter=',')
 
-    f = open(output_file, 'wb')
+    f = open(output_file, 'w')
     output_writer = csv.writer(f)
 
     skip_count = skip
     for row in input_reader:
         if skip_count == skip:
-            output_writer.writerow(row)
+            output_writer.writerow([r.encode() for r in row])
             skip_count = 0
             
         skip_count = skip_count + 1
@@ -70,9 +70,9 @@ def make_sparse_skip(csv_file, skip):
 def make_sparse_length(csv_file, length):
     output_file = csv_file[:-4] + '_sprs_len.csv'
 
-    input_reader = csv.reader(open(csv_file, 'rb'))
+    input_reader = csv.reader(open(csv_file, newline=''), delimiter=',')
 
-    f = open(output_file, 'wb')
+    f = open(output_file, 'w')
     output_writer = csv.writer(f)
 
     # Calculate skip count for file

--- a/diagnostic_analysis/test/bag_csv_test.py
+++ b/diagnostic_analysis/test/bag_csv_test.py
@@ -61,7 +61,7 @@ def make_status_msg(count):
     stat.message = 'OK'
     stat.name = 'Unit Test'
     stat.hardware_id = 'HW ID'
-    stat.values = [ 
+    stat.values = [
         KeyValue('Value A', str(count)),
         KeyValue('Value B', str(count)),
         KeyValue('Value C', str(count))]
@@ -97,7 +97,7 @@ class TestBagToCSV(unittest.TestCase):
     ##\brief Test that CSV file has correct data, number of lines
     def test_export(self):
         # Read CSV, count rows
-        input_reader = csv.reader(open(self.filename, 'rb'))
+        input_reader = csv.reader(open(self.filename, newline=''), delimiter=',')
         count = -1
         for row in input_reader:
             if count == -1:

--- a/diagnostic_common_diagnostics/CMakeLists.txt
+++ b/diagnostic_common_diagnostics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(diagnostic_common_diagnostics)
 
 # Load catkin and all dependencies required for this package

--- a/diagnostic_common_diagnostics/package.xml
+++ b/diagnostic_common_diagnostics/package.xml
@@ -21,7 +21,7 @@
   <run_depend>hddtemp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>python-psutil</run_depend>
+  <run_depend>python3-psutil</run_depend>
 
   <!-- <test_depend>diagnostic_updater</test_depend> -->
   <!-- <test_depend>rospy</test_depend> -->

--- a/diagnostic_common_diagnostics/setup.py
+++ b/diagnostic_common_diagnostics/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/hd_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/hd_monitor.py
@@ -362,7 +362,7 @@ if __name__ == '__main__':
     try:
         rospy.init_node('hd_monitor_%s' % hostname_clean)
     except rospy.exceptions.ROSInitException:
-        print 'HD monitor is unable to initialize node. Master may not be running.'
+        print('HD monitor is unable to initialize node. Master may not be running.')
         sys.exit(0)
 
     hd_monitor = hd_monitor(hostname, options.diag_hostname, home_dir)
@@ -374,7 +374,7 @@ if __name__ == '__main__':
             hd_monitor.publish_stats()
     except KeyboardInterrupt:
         pass
-    except Exception, e:
+    except Exception as e:
         traceback.print_exc()
 
     hd_monitor.cancel_timers()

--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/ntp_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/ntp_monitor.py
@@ -50,7 +50,7 @@ def ntp_diag(st, host, off, error_offset):
         p = Popen(["ntpdate", "-q", host], stdout=PIPE, stdin=PIPE, stderr=PIPE)
         res = p.wait()
         (o,e) = p.communicate()
-    except OSError, (errno, msg):
+    except OSError as errno:
         if errno == 4:
             return None #ctrl-c interrupt
         else:

--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
@@ -205,7 +205,7 @@ class SensorsMonitor(object):
                         if sensor.getInput() < sensor.getMin():
                             stat.mergeSummary(DIAG.ERROR, "No Fan Speed")
                     stat.add(" ".join([sensor.getName(), sensor.getType()]), sensor.getInput())
-        except Exception, e:
+        except Exception as e:
             import traceback
             rospy.logerr('Unable to process lm-sensors data')
             rospy.logerr(traceback.format_exc())
@@ -217,7 +217,7 @@ if __name__ == '__main__':
     try:
         rospy.init_node('sensors_monitor_%s'%hostname_clean)
     except rospy.ROSInitException:
-        print >> sys.stderr, 'Unable to initialize node. Master may not be running'
+        print('Unable to initialize node. Master may not be running')
         sys.exit(0)
 
     monitor = SensorsMonitor(hostname)

--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
@@ -217,7 +217,7 @@ if __name__ == '__main__':
     try:
         rospy.init_node('sensors_monitor_%s'%hostname_clean)
     except rospy.ROSInitException:
-        print('Unable to initialize node. Master may not be running')
+        print(file=sys.stderr, 'Unable to initialize node. Master may not be running')
         sys.exit(0)
 
     monitor = SensorsMonitor(hostname)

--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/tf_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/tf_monitor.py
@@ -68,7 +68,7 @@ def rostime_delta(ctx):
                     deltas[callerid]  = secs
 
     errors = []
-    for k, v in deltas.iteritems():
+    for k, v in deltas.items():
         errors.append("receiving transform from [%s] that differed from ROS time by %ss"%(k, v))
     return errors
 

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(diagnostic_updater)
 
 # Load catkin and all dependencies required for this package

--- a/diagnostic_updater/setup.py
+++ b/diagnostic_updater/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/diagnostic_updater/src/diagnostic_updater/_update_functions.py
+++ b/diagnostic_updater/src/diagnostic_updater/_update_functions.py
@@ -112,7 +112,7 @@ class FrequencyStatus(DiagnosticTask):
                 stat.summary(2, "No events recorded.")
             elif freq < self.params.freq_bound['min'] * (1 - self.params.tolerance):
                 stat.summary(1, "Frequency too low.")
-            elif self.params.freq_bound.has_key('max') and freq > self.params.freq_bound['max'] * (1 + self.params.tolerance):
+            elif 'max' in self.params.freq_bound and freq > self.params.freq_bound['max'] * (1 + self.params.tolerance):
                 stat.summary(1, "Frequency too high.")
             else:
                 stat.summary(0, "Desired frequency met")
@@ -121,11 +121,11 @@ class FrequencyStatus(DiagnosticTask):
             stat.add("Events since startup", "%d" % self.count)
             stat.add("Duration of window (s)", "%f" % window)
             stat.add("Actual frequency (Hz)", "%f" % freq)
-            if self.params.freq_bound.has_key('max') and self.params.freq_bound['min'] == self.params.freq_bound['max']:
+            if 'max' in self.params.freq_bound and self.params.freq_bound['min'] == self.params.freq_bound['max']:
                 stat.add("Target frequency (Hz)", "%f" % self.params.freq_bound['min'])
             if self.params.freq_bound['min'] > 0:
                 stat.add("Minimum acceptable frequency (Hz)", "%f" % (self.params.freq_bound['min'] * (1 - self.params.tolerance)))
-            if self.params.freq_bound.has_key('max'):
+            if 'max' in self.params.freq_bound:
                 stat.add("Maximum acceptable frequency (Hz)", "%f" % (self.params.freq_bound['max'] * (1 + self.params.tolerance)))
 
         return stat

--- a/diagnostics/CMakeLists.txt
+++ b/diagnostics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(diagnostics)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/rosdiagnostic/CMakeLists.txt
+++ b/rosdiagnostic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosdiagnostic)
 
 find_package(catkin REQUIRED)

--- a/rosdiagnostic/setup.py
+++ b/rosdiagnostic/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/self_test/CMakeLists.txt
+++ b/self_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(self_test)
 
 # Load catkin and all dependencies required for this package

--- a/self_test/scripts/test_selftest.py
+++ b/self_test/scripts/test_selftest.py
@@ -78,12 +78,12 @@ class TestSelfTest(unittest.TestCase):
 
         try:
             rospy.wait_for_service(SRV_NAME, 15)
-        except Exception, e:
+        except Exception as e:
             self.assert_(False, "Service %s did not respond. Unable to test self_test" % SRV_NAME)
 
         try:
             res = proxy()
-        except Exception, e:
+        except Exception as e:
             import traceback
             self.assert_(False, "Error calling self_test service. Exception: %s" % traceback.format_exc())
 

--- a/test_diagnostic_aggregator/CMakeLists.txt
+++ b/test_diagnostic_aggregator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(test_diagnostic_aggregator)
 
 # Load catkin and all dependencies required for this package


### PR DESCRIPTION
- Python3 changes

- Use setuptools instead of distutils 

Since ros/catkin#1048 catkin prefers to use setuptools instead of distutils. The package.xml doesn't need to include python3-setuptools because [catkin exports that dependency](https://github.com/ros/catkin/blob/86439ec5d2010d5c47c30b815aa97e525037930f/package.xml#L32) for the convenience of all downstream python packages.

- Bump CMake version to avoid CMP0048

This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.