### PR TITLE
Allow zero analyzers without error

### DIFF
--- a/diagnostic_aggregator/src/analyzer_group.cpp
+++ b/diagnostic_aggregator/src/analyzer_group.cpp
@@ -154,8 +154,8 @@ bool AnalyzerGroup::init(const string base_path, const ros::NodeHandle &n)
 
   if (analyzers_.size() == 0)
   {
-    init_ok = false;
-    ROS_ERROR("No analyzers initialized in AnalyzerGroup %s", analyzers_nh.getNamespace().c_str());
+    // This isn't an error if the user didn't configure any analyzer groups
+    ROS_INFO("No analyzers initialized in AnalyzerGroup %s", analyzers_nh.getNamespace().c_str());
   }
 
   return init_ok;


### PR DESCRIPTION
I'm using the aggregator to see the diagnostics without analysis, and don't want an error message when it starts up.