### PR TITLE
Fix python positional argument

### DIFF
--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
@@ -217,7 +217,7 @@ if __name__ == '__main__':
     try:
         rospy.init_node('sensors_monitor_%s'%hostname_clean)
     except rospy.ROSInitException:
-        print(file=sys.stderr, 'Unable to initialize node. Master may not be running')
+        print('Unable to initialize node. Master may not be running', file=sys.stderr)
         sys.exit(0)
 
     monitor = SensorsMonitor(hostname)


### PR DESCRIPTION
```
  File "lib/python3.6/site-packages/diagnostic_common_diagnostics/sensors_monitor.py", line 220
    print(file=sys.stderr, 'Unable to initialize node. Master may not be running')
                          ^
SyntaxError: positional argument follows keyword argument
```