### PR TITLE
fix shebang line for python3

### DIFF
--- a/diagnostic_common_diagnostics/CMakeLists.txt
+++ b/diagnostic_common_diagnostics/CMakeLists.txt
@@ -19,7 +19,7 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/launch/test_cpu_monitor_level_warn.launch)
 endif()
 
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   src/diagnostic_common_diagnostics/cpu_monitor.py
   src/diagnostic_common_diagnostics/hd_monitor.py
   src/diagnostic_common_diagnostics/ntp_monitor.py

--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/sensors_monitor.py
@@ -217,7 +217,7 @@ if __name__ == '__main__':
     try:
         rospy.init_node('sensors_monitor_%s'%hostname_clean)
     except rospy.ROSInitException:
-        print(file=sys.stderr, 'Unable to initialize node. Master may not be running')
+        print('Unable to initialize node. Master may not be running', file=sys.stderr)
         sys.exit(0)
 
     monitor = SensorsMonitor(hostname)


### PR DESCRIPTION
Similar to https://github.com/ros-visualization/rqt_graph/pull/43

Without this change the script cannot be rosrun on Noetic/Focal and results in:
`/usr/bin/env: ‘python’: No such file or directory`

Python scripts need to be installed using `catkin_install_python` for the shebang line to be rewritten to point to python3. More details at https://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs

@Karsten1987 @sloretz FYI