### PR TITLE
Better support for slow topics

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -176,21 +176,23 @@ namespace diagnostic_updater
         times_[hist_indx_] = curtime;
         hist_indx_ = (hist_indx_ + 1) % params_.window_size_;
 
+        using diagnostic_msgs::DiagnosticStatus;
+
         if (events == 0)
         {
-          stat.summary(2, "No events recorded.");
+          stat.summary(DiagnosticStatus::ERROR, "No events recorded.");
         }
         else if (freq < *params_.min_freq_ * (1 - params_.tolerance_))
         {
-          stat.summary(1, "Frequency too low.");
+          stat.summary(DiagnosticStatus::WARN, "Frequency too low.");
         }
         else if (freq > *params_.max_freq_ * (1 + params_.tolerance_))
         {
-          stat.summary(1, "Frequency too high.");
+          stat.summary(DiagnosticStatus::WARN, "Frequency too high.");
         }
         else
         {
-          stat.summary(0, "Desired frequency met");
+          stat.summary(DiagnosticStatus::OK, "Desired frequency met");
         }
 
         stat.addf("Events in window", "%d", events);
@@ -354,28 +356,30 @@ namespace diagnostic_updater
       {
         boost::mutex::scoped_lock lock(lock_);
 
-        stat.summary(0, "Timestamps are reasonable.");
+        using diagnostic_msgs::DiagnosticStatus;
+        
+        stat.summary(DiagnosticStatus::OK, "Timestamps are reasonable.");
         if (!deltas_valid_)
         {
-          stat.summary(1, "No data since last update.");
+          stat.summary(DiagnosticStatus::WARN, "No data since last update.");
         }
         else
         {
           if (min_delta_ < params_.min_acceptable_)
           {
-            stat.summary(2, "Timestamps too far in future seen.");
+            stat.summary(DiagnosticStatus::ERROR, "Timestamps too far in future seen.");
             early_count_++;
           }
 
           if (max_delta_ > params_.max_acceptable_)
           {
-            stat.summary(2, "Timestamps too far in past seen.");
+            stat.summary(DiagnosticStatus::ERROR, "Timestamps too far in past seen.");
             late_count_++;
           }
 
           if (zero_seen_)
           {
-            stat.summary(2, "Zero timestamp seen.");
+            stat.summary(DiagnosticStatus::ERROR, "Zero timestamp seen.");
             zero_count_++;
           }
         }

--- a/diagnostic_updater/include/diagnostic_updater/update_functions.h
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.h
@@ -227,11 +227,7 @@ namespace diagnostic_updater
      */
 
     TimeStampStatusParam(const double min_acceptable = -1, const double max_acceptable = 5) :
-      max_acceptable_(max_acceptable), min_acceptable_(min_acceptable), no_data_is_problem_(true)
-    {}
-
-    TimeStampStatusParam(const double min_acceptable, const double max_acceptable, const bool no_data_is_problem) :
-      max_acceptable_(max_acceptable), min_acceptable_(min_acceptable), no_data_is_problem_(no_data_is_problem)
+      max_acceptable_(max_acceptable), min_acceptable_(min_acceptable)
     {}
 
     /**
@@ -245,11 +241,6 @@ namespace diagnostic_updater
      */
 
     double min_acceptable_;
-
-    /**
-     * \brief Whether to report a warning when no data arrived since last update.
-     */
-    bool no_data_is_problem_;
   };
 
   /**
@@ -360,56 +351,7 @@ namespace diagnostic_updater
         tick(t.toSec());
       }
 
-      virtual void run(diagnostic_updater::DiagnosticStatusWrapper &stat)
-      {
-        boost::mutex::scoped_lock lock(lock_);
-
-        using diagnostic_msgs::DiagnosticStatus;
-        
-        stat.summary(DiagnosticStatus::OK, "Timestamps are reasonable.");
-        if (!deltas_valid_)
-        {
-          const auto status = params_.no_data_is_problem_ ? DiagnosticStatus::WARN : DiagnosticStatus::OK;
-          stat.summary(status, "No data since last update.");
-
-          stat.add("Earliest timestamp delay:", "No data");
-          stat.add("Latest timestamp delay:", "No data");
-        }
-        else
-        {
-          if (min_delta_ < params_.min_acceptable_)
-          {
-            stat.summary(DiagnosticStatus::ERROR, "Timestamps too far in future seen.");
-            early_count_++;
-          }
-
-          if (max_delta_ > params_.max_acceptable_)
-          {
-            stat.summary(DiagnosticStatus::ERROR, "Timestamps too far in past seen.");
-            late_count_++;
-          }
-
-          if (zero_seen_)
-          {
-            stat.summary(DiagnosticStatus::ERROR, "Zero timestamp seen.");
-            zero_count_++;
-          }
-
-          stat.addf("Earliest timestamp delay:", "%f", min_delta_);
-          stat.addf("Latest timestamp delay:", "%f", max_delta_);
-        }
-
-        stat.addf("Earliest acceptable timestamp delay:", "%f", params_.min_acceptable_);
-        stat.addf("Latest acceptable timestamp delay:", "%f", params_.max_acceptable_);
-        stat.add("Late diagnostic update count:", late_count_);
-        stat.add("Early diagnostic update count:", early_count_);
-        stat.add("Zero seen diagnostic update count:", zero_count_);
-
-        deltas_valid_ = false;
-        min_delta_ = 0;
-        max_delta_ = 0;
-        zero_seen_ = false;
-      }
+      virtual void run(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
     private:
       TimeStampStatusParam params_;
@@ -422,6 +364,75 @@ namespace diagnostic_updater
       bool deltas_valid_;
       boost::mutex lock_;
   };
+
+  /**
+   * A TimeStampStatus task that doesn't report periods with no data as a warning. This comes handy if the diagnosed
+   * topic has lower frequency than the diagnostic period.
+   */
+  class SlowTimeStampStatus : public TimeStampStatus
+  {
+    public:
+      SlowTimeStampStatus(const TimeStampStatusParam& params, const std::string& name) : TimeStampStatus(params, name)
+      {}
+
+      SlowTimeStampStatus(const TimeStampStatusParam& params) : TimeStampStatus(params)
+      {}
+
+      SlowTimeStampStatus()
+      {}
+  };
+
+  void TimeStampStatus::run(DiagnosticStatusWrapper& stat)
+  {
+    boost::mutex::scoped_lock lock(lock_);
+
+    using diagnostic_msgs::DiagnosticStatus;
+
+    stat.summary(DiagnosticStatus::OK, "Timestamps are reasonable.");
+    if (!deltas_valid_)
+    {
+      const auto no_data_is_problem = dynamic_cast<SlowTimeStampStatus*>(this) == nullptr;
+      const auto status = no_data_is_problem ? DiagnosticStatus::WARN : DiagnosticStatus::OK;
+      stat.summary(status, "No data since last update.");
+
+      stat.add("Earliest timestamp delay:", "No data");
+      stat.add("Latest timestamp delay:", "No data");
+    }
+    else
+    {
+      if (min_delta_ < params_.min_acceptable_)
+      {
+        stat.summary(DiagnosticStatus::ERROR, "Timestamps too far in future seen.");
+        early_count_++;
+      }
+
+      if (max_delta_ > params_.max_acceptable_)
+      {
+        stat.summary(DiagnosticStatus::ERROR, "Timestamps too far in past seen.");
+        late_count_++;
+      }
+
+      if (zero_seen_)
+      {
+        stat.summary(DiagnosticStatus::ERROR, "Zero timestamp seen.");
+        zero_count_++;
+      }
+
+      stat.addf("Earliest timestamp delay:", "%f", min_delta_);
+      stat.addf("Latest timestamp delay:", "%f", max_delta_);
+    }
+
+    stat.addf("Earliest acceptable timestamp delay:", "%f", params_.min_acceptable_);
+    stat.addf("Latest acceptable timestamp delay:", "%f", params_.max_acceptable_);
+    stat.add("Late diagnostic update count:", late_count_);
+    stat.add("Early diagnostic update count:", early_count_);
+    stat.add("Zero seen diagnostic update count:", zero_count_);
+
+    deltas_valid_ = false;
+    min_delta_ = 0;
+    max_delta_ = 0;
+    zero_seen_ = false;
+  }
 
  /**
  * \brief Diagnostic task to monitor whether a node is alive

--- a/diagnostic_updater/test/diagnostic_updater_test.cpp
+++ b/diagnostic_updater/test/diagnostic_updater_test.cpp
@@ -170,11 +170,13 @@ TEST(DiagnosticUpdater, testFrequencyStatus)
   fs.clear();
   fs.run(stat[4]); // Should be good, just cleared it.
 
-  EXPECT_EQ(1, stat[0].level) << "max frequency exceeded but not reported";
-  EXPECT_EQ(0, stat[1].level) << "within max frequency but reported error";
-  EXPECT_EQ(0, stat[2].level) << "within min frequency but reported error";
-  EXPECT_EQ(1, stat[3].level) << "min frequency exceeded but not reported";
-  EXPECT_EQ(2, stat[4].level) << "freshly cleared should fail";
+  using diagnostic_msgs::DiagnosticStatus;
+
+  EXPECT_EQ(DiagnosticStatus::WARN, stat[0].level) << "max frequency exceeded but not reported";
+  EXPECT_EQ(DiagnosticStatus::OK, stat[1].level) << "within max frequency but reported error";
+  EXPECT_EQ(DiagnosticStatus::OK, stat[2].level) << "within min frequency but reported error";
+  EXPECT_EQ(DiagnosticStatus::WARN, stat[3].level) << "min frequency exceeded but not reported";
+  EXPECT_EQ(DiagnosticStatus::ERROR, stat[4].level) << "freshly cleared should fail";
   EXPECT_STREQ("", stat[0].name.c_str()) << "Name should not be set by FrequencyStatus";
   EXPECT_STREQ("Frequency Status", fs.getName().c_str()) << "Name should be \"Frequency Status\"";
 }
@@ -197,12 +199,14 @@ TEST(DiagnosticUpdater, testTimeStampStatus)
   ts.run(stat[3]);
   ts.tick(time.toSec() - 6);
   ts.run(stat[4]);
- 
-  EXPECT_EQ(1, stat[0].level) << "no data should return a warning";
-  EXPECT_EQ(2, stat[1].level) << "too far future not reported";
-  EXPECT_EQ(0, stat[2].level) << "now not accepted";
-  EXPECT_EQ(0, stat[3].level) << "4 seconds ago not accepted";
-  EXPECT_EQ(2, stat[4].level) << "too far past not reported";
+
+  using diagnostic_msgs::DiagnosticStatus;
+
+  EXPECT_EQ(DiagnosticStatus::WARN, stat[0].level) << "no data should return a warning";
+  EXPECT_EQ(DiagnosticStatus::ERROR, stat[1].level) << "too far future not reported";
+  EXPECT_EQ(DiagnosticStatus::OK, stat[2].level) << "now not accepted";
+  EXPECT_EQ(DiagnosticStatus::OK, stat[3].level) << "4 seconds ago not accepted";
+  EXPECT_EQ(DiagnosticStatus::ERROR, stat[4].level) << "too far past not reported";
   EXPECT_STREQ("", stat[0].name.c_str()) << "Name should not be set by TimeStapmStatus";
   EXPECT_STREQ("Timestamp Status", ts.getName().c_str()) << "Name should be \"Timestamp Status\"";
 }

--- a/diagnostic_updater/test/diagnostic_updater_test.cpp
+++ b/diagnostic_updater/test/diagnostic_updater_test.cpp
@@ -268,7 +268,7 @@ TEST(DiagnosticUpdater, testSlowTimeStampStatus)
   ros::Time time(1, 0);
   ros::Time::setNow(time);
 
-  TimeStampStatus ts(TimeStampStatusParam(-1, 5, false));
+  SlowTimeStampStatus ts(TimeStampStatusParam(-1, 5));
 
   DiagnosticStatusWrapper stat[11];
   ts.run(stat[0]); // no events


### PR DESCRIPTION
This PR provides a solution for #45.

It adds a test for FrequencyStatus for the case when a topic is published on a slower rate than 1/diagnostic_period.

For TimeStampStatus, it adds a parameter `no_data_is_problem_` which allows to specify whether an "empty run()" should be treated as error (for slow topics, it is okay when there are updates without any data).

The last commit is an ABI break (API remains compatible). I needed to add the field to remember whether to treat no data as error or not. There are ways to get around the ABI break, but none of them is good (either a global static map<TimeStampStatus, bool> with a lock, or "misusing" some higher bits in one of the private parameters of TimeStampStatus).