### PR TITLE
diagnostic_aggregator: Fixed flaky test.

### DIFF
--- a/diagnostic_aggregator/test/discard_stale_not_published_test.py
+++ b/diagnostic_aggregator/test/discard_stale_not_published_test.py
@@ -88,6 +88,7 @@ class TestDiscardStale(unittest.TestCase):
                                                  "Received diagnostics: {}".format(expecteds))
         self.assert_(expecteds['nonexistent2'].level == DiagnosticStatus.WARN)
 
+        self._start_time = rospy.get_time()
         duration = 8
         # waiting a bit more than 5 seconds for the messages to become stale
         while not rospy.is_shutdown():
@@ -104,7 +105,8 @@ class TestDiscardStale(unittest.TestCase):
             self.assert_(self._agg_expecteds[0].level == DiagnosticStatus.STALE,
                          "The level of the first aggregated message should be stale!")
 
-        duration = 15
+        self._start_time = rospy.get_time()
+        duration = 8
         # waiting a bit more than 5 seconds for the timeout of the aggregator to kick in
         while not rospy.is_shutdown():
             sleep(1.0)


### PR DESCRIPTION
discard_stale_not_published_test.py had an initial wait for /diagnostics topic and a subsequent wait for stale agg messages. If, however, the initial wait for /diagnostics took longer (e.g. high CPU utilization), it decreased the amount of time left to wait for stale messages. The fix makes these wait times independent.

Example build when the test failed: http://build.ros.org/job/Npr__diagnostics__ubuntu_focal_amd64/10