### PR TITLE
restore alphabetical order

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -11,9 +11,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-# order matters here: https://github.com/ros2/ros2/issues/927
-find_package(pluginlib REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 


### PR DESCRIPTION
The issue listed in https://github.com/ros2/ros2/issues/927 got resolved, which allows an alphabetical include order