### PR TITLE
[ROS2] increase history_depth for subscrition

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -139,6 +139,7 @@ private:
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr toplevel_state_pub_;
   std::mutex mutex_;
   double pub_rate_;
+  int history_depth_;
   rclcpp::Clock::SharedPtr clock_;
 
   /*!

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -62,6 +62,7 @@ Aggregator::Aggregator()
       rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true))),
   logger_(rclcpp::get_logger("Aggregator")),
   pub_rate_(1.0),
+  history_depth_(1000),
   clock_(new rclcpp::Clock()),
   base_path_("/")
 {
@@ -81,6 +82,8 @@ Aggregator::Aggregator()
       base_path_.append(param.second.as_string());
     } else if (param.first.compare("other_as_errors") == 0) {
       other_as_errors = param.second.as_bool();
+    } else if (param.first.compare("history_depth") == 0) {
+      history_depth_ = param.second.as_int();
     }
   }
   RCLCPP_DEBUG(logger_, "Aggregator publication rate configured to: %f", pub_rate_);
@@ -97,9 +100,9 @@ Aggregator::Aggregator()
   other_analyzer_ = std::make_unique<OtherAnalyzer>(other_as_errors);
   other_analyzer_->init(base_path_);  // This always returns true
 
-  diag_sub_ = n_->create_subscription<DiagnosticArray>(
-    "/diagnostics", rclcpp::SystemDefaultsQoS(), std::bind(&Aggregator::diagCallback, this, _1));
-  agg_pub_ = n_->create_publisher<DiagnosticArray>("/diagnostics_agg", 1);
+  diag_sub_ = n_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+    "/diagnostics", rclcpp::SystemDefaultsQoS().keep_last(history_depth_), std::bind(&Aggregator::diagCallback, this, _1));
+  agg_pub_ = n_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics_agg", 1);
   toplevel_state_pub_ =
     n_->create_publisher<DiagnosticStatus>("/diagnostics_toplevel_state", 1);
 

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -100,9 +100,10 @@ Aggregator::Aggregator()
   other_analyzer_ = std::make_unique<OtherAnalyzer>(other_as_errors);
   other_analyzer_->init(base_path_);  // This always returns true
 
-  diag_sub_ = n_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-    "/diagnostics", rclcpp::SystemDefaultsQoS().keep_last(history_depth_), std::bind(&Aggregator::diagCallback, this, _1));
-  agg_pub_ = n_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics_agg", 1);
+  diag_sub_ = n_->create_subscription<DiagnosticArray>(
+    "/diagnostics", rclcpp::SystemDefaultsQoS().keep_last(history_depth_),
+    std::bind(&Aggregator::diagCallback, this, _1));
+  agg_pub_ = n_->create_publisher<DiagnosticArray>("/diagnostics_agg", 1);
   toplevel_state_pub_ =
     n_->create_publisher<DiagnosticStatus>("/diagnostics_toplevel_state", 1);
 


### PR DESCRIPTION
This resolves issue : https://github.com/ros/diagnostics/issues/167.

This makes the following modfiication:
* The new parameter `history_depth` for diagnostic_aggregator node to enable users to set history depth size(i.e. queue size) for subscription.
* Change default depth size to 1000 from 1.

Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>