### PR TITLE
[ROS2] Move Aggregator publishing to timer to allow subscription callback more processing time

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -114,22 +114,6 @@ public:
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   virtual ~Aggregator();
 
-  /*!
-   *\brief Processes, publishes data. Should be called at pub_rate.
-   */
-  DIAGNOSTIC_AGGREGATOR_PUBLIC
-  void publishData();
-
-  /*!
-   *\brief True if the NodeHandle reports OK
-   */
-  bool ok() const {return rclcpp::ok();}
-
-  /*!
-   *\brief Publish rate defaults to 1Hz, but can be set with ~pub_rate param
-   */
-  double getPubRate() const {return pub_rate_;}
-
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   rclcpp::Node::SharedPtr get_node() const;
 
@@ -137,6 +121,7 @@ private:
   rclcpp::Node::SharedPtr n_;
 
   rclcpp::Logger logger_;
+  rclcpp::TimerBase::SharedPtr publish_timer_;
 
   /// AddDiagnostics, /diagnostics_agg/add_diagnostics
   rclcpp::Service<diagnostic_msgs::srv::AddDiagnostics>::SharedPtr add_srv_;
@@ -162,6 +147,11 @@ private:
 
   /// Records all ROS warnings. No warnings are repeated.
   std::set<std::string> ros_warnings_;
+
+  /*!
+   *\brief Processes, publishes data. Should be called at pub_rate.
+   */
+  void publishData();
 
   /*
    *!\brief Checks timestamp of message, and warns if timestamp is 0 (not set)

--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -114,6 +114,12 @@ public:
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   virtual ~Aggregator();
 
+  /*!
+   *\brief Processes, publishes data. Should be called at pub_rate.
+   */
+  DIAGNOSTIC_AGGREGATOR_PUBLIC
+  void publishData();
+
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   rclcpp::Node::SharedPtr get_node() const;
 
@@ -147,11 +153,6 @@ private:
 
   /// Records all ROS warnings. No warnings are repeated.
   std::set<std::string> ros_warnings_;
-
-  /*!
-   *\brief Processes, publishes data. Should be called at pub_rate.
-   */
-  void publishData();
 
   /*
    *!\brief Checks timestamp of message, and warns if timestamp is 0 (not set)

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -37,12 +37,12 @@
 
 #include "diagnostic_aggregator/aggregator.hpp"
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
-#include <chrono>
 
 namespace diagnostic_aggregator
 {

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -98,8 +98,7 @@ Aggregator::Aggregator()
   other_analyzer_->init(base_path_);  // This always returns true
 
   diag_sub_ = n_->create_subscription<DiagnosticArray>(
-    "/diagnostics", rclcpp::SystemDefaultsQoS().keep_last(1000),
-    std::bind(&Aggregator::diagCallback, this, _1));
+    "/diagnostics", rclcpp::SystemDefaultsQoS(), std::bind(&Aggregator::diagCallback, this, _1));
   agg_pub_ = n_->create_publisher<DiagnosticArray>("/diagnostics_agg", 1);
   toplevel_state_pub_ =
     n_->create_publisher<DiagnosticStatus>("/diagnostics_toplevel_state", 1);

--- a/diagnostic_aggregator/src/aggregator_node.cpp
+++ b/diagnostic_aggregator/src/aggregator_node.cpp
@@ -34,10 +34,10 @@
 
 /**< \author Kevin Watts */
 
+#include "diagnostic_aggregator/aggregator.hpp"
+
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
-
-#include "diagnostic_aggregator/aggregator.hpp"
 
 int main(int argc, char ** argv)
 {

--- a/diagnostic_aggregator/src/aggregator_node.cpp
+++ b/diagnostic_aggregator/src/aggregator_node.cpp
@@ -37,7 +37,8 @@
 #include "diagnostic_aggregator/aggregator.hpp"
 
 #include <memory>
-#include <rclcpp/rclcpp.hpp>
+
+#include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char ** argv)
 {

--- a/diagnostic_aggregator/src/aggregator_node.cpp
+++ b/diagnostic_aggregator/src/aggregator_node.cpp
@@ -34,34 +34,21 @@
 
 /**< \author Kevin Watts */
 
-#include <exception>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
 
 #include "diagnostic_aggregator/aggregator.hpp"
-
-#include "rclcpp/executors.hpp"
-
-using std::exception;
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  try {
-    diagnostic_aggregator::Aggregator agg;
+  rclcpp::executors::SingleThreadedExecutor exec;
+  auto agg = std::make_shared<diagnostic_aggregator::Aggregator>();
+  exec.add_node(agg->get_node());
+  exec.spin();
 
-    rclcpp::Rate pub_rate(agg.getPubRate());
-    while (rclcpp::ok()) {
-      rclcpp::spin_some(agg.get_node());
-      agg.publishData();
-      pub_rate.sleep();
-    }
-  } catch (const exception & e) {
-    RCLCPP_FATAL(
-      rclcpp::get_logger("aggregator_node"),
-      "Diagnostic aggregator node caught exception. Aborting. %s", e.what());
-    rclcpp::shutdown();
-  }
+  rclcpp::shutdown();
 
-  exit(0);
   return 0;
 }


### PR DESCRIPTION
Moving the aggregator's publishing to a wall timer, and letting the node spin continuously, permits the subscription callback to operate at the necessary rate of incoming diagnostic entry messages.