### PR TITLE
[ROS2] Enable multiple tasks publishing for diagnostic updater 

### DIFF
--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -329,18 +329,19 @@ class Updater(DiagnosticTaskVector):
         if not type(msg) is list:
             msg = [msg]
 
+        now = self.clock.now()
+        da = DiagnosticArray()
+        da.header.stamp = now.to_msg()  # Add timestamp for ROS 0.10
         for stat in msg:
             stat.name = self.node.get_name() + ': ' + stat.name
-        now = self.clock.now()
+            db = DiagnosticStatus()
+            db.name = stat.name
+            db.message = stat.message
+            db.hardware_id = stat.hardware_id
+            db.values = stat.values
+            db.level = stat.level
+            da.status.append(db)
 
-        da = DiagnosticArray()
-        db = DiagnosticStatus()
-        db.name = stat.name
-        db.message = stat.message
-        db.hardware_id = stat.hardware_id
-        db.values = stat.values
-        da.status.append(db)
-        da.header.stamp = now.to_msg()  # Add timestamp for ROS 0.10
         self.publisher.publish(da)
 
     def addedTaskCallback(self, task):


### PR DESCRIPTION
Currently, the publish() function of the Updater() class in _diagnostic_updater.py seems bugged.

A DiagnosticStatus is only created for the last stat in msg, while it should be for every stat in msg.
This means that only a single DiagnosticStatus is published instead of all the DiagnosticStatus.

This Pull Request fixes this by creating a DiagnositcStatus in the for loop and appending it to the DiagnosticArray.

This is a copy of https://github.com/ros/diagnostics/pull/181, but with target ros2-devel.