### PR TITLE
[ROS2] Fix setting of diagnostic status level by diagnostic updater 

### DIFF
--- a/diagnostic_updater/diagnostic_updater/_diagnostic_status_wrapper.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_status_wrapper.py
@@ -88,7 +88,7 @@ class DiagnosticStatusWrapper(DiagnosticStatus):
 
     def clearSummary(self):
         """Clear the summary, setting the level to zero and the message to."""
-        self.summary(b'0', '')
+        self.summary(b'\x00', '')
 
     def mergeSummary(self, *args):
         """
@@ -115,7 +115,7 @@ class DiagnosticStatusWrapper(DiagnosticStatus):
             lvl = args[0]
             msg = args[1]
 
-        if (lvl > b'0') == (self.level > b'0'):
+        if (lvl > b'\x00') == (self.level > b'\x00'):
             if len(self.message) > 0:
                 self.message += '; '
             self.message += msg

--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -249,7 +249,7 @@ class Updater(DiagnosticTaskVector):
         with self.lock:  # Make sure no adds happen while we are processing here.
             for task in self.tasks:
                 status = DiagnosticStatusWrapper()
-                status.level = b'2'
+                status.level = b'\x02'
                 status.name = task.name
                 status.message = 'No message was set'
                 status.hardware_id = self.hwid
@@ -346,5 +346,5 @@ class Updater(DiagnosticTaskVector):
     def addedTaskCallback(self, task):
         stat = DiagnosticStatusWrapper()
         stat.name = task.name
-        stat.summary(b'0', 'Node starting up')
+        stat.summary(b'\x00', 'Node starting up')
         self.publish(stat)

--- a/diagnostic_updater/diagnostic_updater/_update_functions.py
+++ b/diagnostic_updater/diagnostic_updater/_update_functions.py
@@ -115,14 +115,14 @@ class FrequencyStatus(DiagnosticTask):
             self.hist_indx = (self.hist_indx + 1) % self.params.window_size
 
             if events == 0:
-                stat.summary(b'2', 'No events recorded.')
+                stat.summary(b'\x02', 'No events recorded.')
             elif freq < self.params.freq_bound['min'] * (1 - self.params.tolerance):
-                stat.summary(b'1', 'Frequency too low.')
+                stat.summary(b'\x01', 'Frequency too low.')
             elif 'max' in self.params.freq_bound and freq > self.params.freq_bound['max'] *\
                  (1 + self.params.tolerance):
-                stat.summary(b'1', 'Frequency too high.')
+                stat.summary(b'\x01', 'Frequency too high.')
             else:
-                stat.summary(b'0', 'Desired frequency met')
+                stat.summary(b'\x00', 'Desired frequency met')
 
             stat.add('Events in window', '%d' % events)
             stat.add('Events since startup', '%d' % self.count)
@@ -206,18 +206,18 @@ class TimeStampStatus(DiagnosticTask):
     def run(self, stat):
         with self.lock:
 
-            stat.summary(b'0', 'Timestamps are reasonable.')
+            stat.summary(b'\x00', 'Timestamps are reasonable.')
             if not self.deltas_valid:
-                stat.summary(b'1', 'No data since last update.')
+                stat.summary(b'\x01', 'No data since last update.')
             else:
                 if self.min_delta < self.params.min_acceptable:
-                    stat.summary(b'2', 'Timestamps too far in future seen.')
+                    stat.summary(b'\x02', 'Timestamps too far in future seen.')
                     self.early_count += 1
                 if self.max_delta > self.params.max_acceptable:
-                    stat.summary(b'2', 'Timestamps too far in past seen.')
+                    stat.summary(b'\x02', 'Timestamps too far in past seen.')
                     self.late_count += 1
                 if self.zero_seen:
-                    stat.summary(b'2', 'Zero timestamp seen.')
+                    stat.summary(b'\x02', 'Zero timestamp seen.')
                     self.zero_count += 1
 
             stat.add('Earliest timestamp delay:', '%f' % self.min_delta)
@@ -248,5 +248,5 @@ class Heartbeat(DiagnosticTask):
         DiagnosticTask.__init__(self, 'Heartbeat')
 
     def run(self, stat):
-        stat.summary(b'0', 'Alive')
+        stat.summary(b'\x00', 'Alive')
         return stat

--- a/diagnostic_updater/diagnostic_updater/example.py
+++ b/diagnostic_updater/diagnostic_updater/example.py
@@ -190,7 +190,7 @@ def main():
 
     # You can broadcast a message in all the DiagnosticStatus if your node
     # is in a special state.
-    updater.broadcast(b'0', 'Doing important initialization stuff.')
+    updater.broadcast(b'\x00', 'Doing important initialization stuff.')
 
     pub1 = node.create_publisher(std_msgs.msg.Bool, 'topic1', 10)
     sleep(2)  # It isn't important if it doesn't take time.

--- a/diagnostic_updater/test/diagnostic_updater_test.py
+++ b/diagnostic_updater/test/diagnostic_updater_test.py
@@ -21,7 +21,7 @@ class ClassFunction(DiagnosticTask):
         DiagnosticTask.__init__(self, 'classFunction')
 
     def run(self, stat):
-        stat.summary(b'0', 'Test is running')
+        stat.summary(b'\x00', 'Test is running')
         stat.add('Value', '%f' % 5)
         stat.add('String', 'Toto')
         stat.add('Floating', 5.55)
@@ -54,7 +54,7 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         stat = DiagnosticStatusWrapper()
 
         message = 'dummy'
-        level = b'1'
+        level = b'\x01'
         stat.summary(level, message)
         self.assertEqual(message, stat.message, 'DiagnosticStatusWrapper::summary failed\
                          to set message')
@@ -105,11 +105,11 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         stat[4] = fs.run(stat[4])
         # Should be good, just cleared it.
 
-        self.assertEqual(b'1', stat[0].level, 'max frequency exceeded but not reported')
-        self.assertEqual(b'0', stat[1].level, 'within max frequency but reported error')
-        self.assertEqual(b'0', stat[2].level, 'within min frequency but reported error')
-        self.assertEqual(b'1', stat[3].level, 'min frequency exceeded but not reported')
-        self.assertEqual(b'2', stat[4].level, 'freshly cleared should fail')
+        self.assertEqual(b'\x01', stat[0].level, 'max frequency exceeded but not reported')
+        self.assertEqual(b'\x00', stat[1].level, 'within max frequency but reported error')
+        self.assertEqual(b'\x00', stat[2].level, 'within min frequency but reported error')
+        self.assertEqual(b'\x01', stat[3].level, 'min frequency exceeded but not reported')
+        self.assertEqual(b'\x02', stat[4].level, 'freshly cleared should fail')
         self.assertEqual('', stat[0].name, 'Name should not be set by FrequencyStatus')
         self.assertEqual('FrequencyStatus', fs.getName(), 'Name should be Frequency Status')
 
@@ -132,11 +132,11 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         ts.tick((now.nanoseconds * 1e-9) - 6)
         stat[4] = ts.run(stat[4])
 
-        self.assertEqual(b'1', stat[0].level, 'no data should return a warning')
-        self.assertEqual(b'2', stat[1].level, 'too far future not reported')
-        self.assertEqual(b'0', stat[2].level, 'now not accepted')
-        self.assertEqual(b'0', stat[3].level, '4 seconds ago not accepted')
-        self.assertEqual(b'2', stat[4].level, 'too far past not reported')
+        self.assertEqual(b'\x01', stat[0].level, 'no data should return a warning')
+        self.assertEqual(b'\x02', stat[1].level, 'too far future not reported')
+        self.assertEqual(b'\x00', stat[2].level, 'now not accepted')
+        self.assertEqual(b'\x00', stat[3].level, '4 seconds ago not accepted')
+        self.assertEqual(b'\x02', stat[4].level, 'too far past not reported')
         self.assertEqual('', stat[0].name, 'Name should not be set by TimeStapmStatus')
         self.assertEqual('Timestamp Status', ts.getName(), 'Name should be Timestamp Status')
 

--- a/diagnostic_updater/test/test_diagnostic_status_wrapper.py
+++ b/diagnostic_updater/test/test_diagnostic_status_wrapper.py
@@ -18,50 +18,50 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         self.assertEqual(d.values, [])
 
     def test_init_lvl_msg(self):
-        d = DiagnosticStatusWrapper(level=b'1', message='test')
-        self.assertEqual(d.level, b'1')
+        d = DiagnosticStatusWrapper(level=b'\x01', message='test')
+        self.assertEqual(d.level, b'\x01')
         self.assertEqual(d.message, 'test')
         self.assertEqual(d.values, [])
 
     def test_summary_lvl_msg(self):
         d = DiagnosticStatusWrapper()
-        d.summary(b'1', 'test')
-        self.assertEqual(d.level, b'1')
+        d.summary(b'\x01', 'test')
+        self.assertEqual(d.level, b'\x01')
         self.assertEqual(d.message, 'test')
 
     def test_summary_dmsg(self):
-        d = DiagnosticStatusWrapper(level=b'0', message='ok')
-        m = DiagnosticStatus(level=b'1', message='warn')
+        d = DiagnosticStatusWrapper(level=b'\x00', message='ok')
+        m = DiagnosticStatus(level=b'\x01', message='warn')
         d.summary(m)
-        self.assertEqual(d.level, b'1')
+        self.assertEqual(d.level, b'\x01')
         self.assertEqual(d.message, 'warn')
 
     def test_clear_summary(self):
-        d = DiagnosticStatusWrapper(level=b'0', message='ok')
+        d = DiagnosticStatusWrapper(level=b'\x00', message='ok')
         d.clearSummary()
-        self.assertEqual(d.level, b'0')
+        self.assertEqual(d.level, b'\x00')
         self.assertEqual(d.message, '')
 
     def test_merge_summary_lvl_msg(self):
-        d = DiagnosticStatusWrapper(level=b'0', message='ok')
-        d.mergeSummary(b'1', 'warn')
-        self.assertEqual(d.level, b'1')
+        d = DiagnosticStatusWrapper(level=b'\x00', message='ok')
+        d.mergeSummary(b'\x01', 'warn')
+        self.assertEqual(d.level, b'\x01')
         self.assertEqual(d.message, 'warn')
 
-        d.mergeSummary(b'2', 'err')
-        self.assertEqual(d.level, b'2')
+        d.mergeSummary(b'\x02', 'err')
+        self.assertEqual(d.level, b'\x02')
         self.assertEqual(d.message, 'warn; err')
 
     def test_merge_summary_dmsg(self):
-        d = DiagnosticStatusWrapper(level=b'0', message='ok')
-        m = DiagnosticStatus(level=b'1', message='warn')
+        d = DiagnosticStatusWrapper(level=b'\x00', message='ok')
+        m = DiagnosticStatus(level=b'\x01', message='warn')
         d.mergeSummary(m)
-        self.assertEqual(d.level, b'1')
+        self.assertEqual(d.level, b'\x01')
         self.assertEqual(d.message, 'warn')
 
-        m = DiagnosticStatus(level=b'2', message='err')
+        m = DiagnosticStatus(level=b'\x02', message='err')
         d.mergeSummary(m)
-        self.assertEqual(d.level, b'2')
+        self.assertEqual(d.level, b'\x02')
         self.assertEqual(d.message, 'warn; err')
 
     def test_add(self):


### PR DESCRIPTION
This PR resolves #183 

It replaces every byte creation b'0' by b'\x00', b'1' by b'\x01', and b'2' by b'\x02'.
With these changes the diagnostic_aggregator_node no longer produces an ERROR.