### PR TITLE
Use DiagnosticStatus.msg values instead of creating bytes manually

### DIFF
--- a/diagnostic_updater/diagnostic_updater/_diagnostic_status_wrapper.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_status_wrapper.py
@@ -40,10 +40,6 @@ diagnostic_updater for Python.
 
 from diagnostic_msgs.msg import DiagnosticStatus, KeyValue
 
-OK = DiagnosticStatus.OK
-WARN = DiagnosticStatus.WARN
-ERROR = DiagnosticStatus.ERROR
-
 
 class DiagnosticStatusWrapper(DiagnosticStatus):
     """
@@ -88,7 +84,7 @@ class DiagnosticStatusWrapper(DiagnosticStatus):
 
     def clearSummary(self):
         """Clear the summary, setting the level to zero and the message to."""
-        self.summary(b'\x00', '')
+        self.summary(DiagnosticStatus.OK, '')
 
     def mergeSummary(self, *args):
         """
@@ -115,7 +111,7 @@ class DiagnosticStatusWrapper(DiagnosticStatus):
             lvl = args[0]
             msg = args[1]
 
-        if (lvl > b'\x00') == (self.level > b'\x00'):
+        if (lvl > DiagnosticStatus.OK) == (self.level > DiagnosticStatus.OK):
             if len(self.message) > 0:
                 self.message += '; '
             self.message += msg

--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -249,7 +249,7 @@ class Updater(DiagnosticTaskVector):
         with self.lock:  # Make sure no adds happen while we are processing here.
             for task in self.tasks:
                 status = DiagnosticStatusWrapper()
-                status.level = b'\x02'
+                status.level = DiagnosticStatus.ERRROR
                 status.name = task.name
                 status.message = 'No message was set'
                 status.hardware_id = self.hwid
@@ -347,5 +347,5 @@ class Updater(DiagnosticTaskVector):
     def addedTaskCallback(self, task):
         stat = DiagnosticStatusWrapper()
         stat.name = task.name
-        stat.summary(b'\x00', 'Node starting up')
+        stat.summary(DiagnosticStatus.OK, 'Node starting up')
         self.publish(stat)

--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -249,7 +249,7 @@ class Updater(DiagnosticTaskVector):
         with self.lock:  # Make sure no adds happen while we are processing here.
             for task in self.tasks:
                 status = DiagnosticStatusWrapper()
-                status.level = DiagnosticStatus.ERRROR
+                status.level = DiagnosticStatus.ERROR
                 status.name = task.name
                 status.message = 'No message was set'
                 status.hardware_id = self.hwid

--- a/diagnostic_updater/diagnostic_updater/_update_functions.py
+++ b/diagnostic_updater/diagnostic_updater/_update_functions.py
@@ -116,7 +116,7 @@ class FrequencyStatus(DiagnosticTask):
             self.hist_indx = (self.hist_indx + 1) % self.params.window_size
 
             if events == 0:
-                stat.summary(DiagnosticStatus.ERRROR, 'No events recorded.')
+                stat.summary(DiagnosticStatus.ERROR, 'No events recorded.')
             elif freq < self.params.freq_bound['min'] * (1 - self.params.tolerance):
                 stat.summary(DiagnosticStatus.WARN, 'Frequency too low.')
             elif 'max' in self.params.freq_bound and freq > self.params.freq_bound['max'] *\
@@ -212,13 +212,13 @@ class TimeStampStatus(DiagnosticTask):
                 stat.summary(DiagnosticStatus.WARN, 'No data since last update.')
             else:
                 if self.min_delta < self.params.min_acceptable:
-                    stat.summary(DiagnosticStatus.ERRROR, 'Timestamps too far in future seen.')
+                    stat.summary(DiagnosticStatus.ERROR, 'Timestamps too far in future seen.')
                     self.early_count += 1
                 if self.max_delta > self.params.max_acceptable:
-                    stat.summary(DiagnosticStatus.ERRROR, 'Timestamps too far in past seen.')
+                    stat.summary(DiagnosticStatus.ERROR, 'Timestamps too far in past seen.')
                     self.late_count += 1
                 if self.zero_seen:
-                    stat.summary(DiagnosticStatus.ERRROR, 'Zero timestamp seen.')
+                    stat.summary(DiagnosticStatus.ERROR, 'Zero timestamp seen.')
                     self.zero_count += 1
 
             stat.add('Earliest timestamp delay:', '%f' % self.min_delta)

--- a/diagnostic_updater/diagnostic_updater/_update_functions.py
+++ b/diagnostic_updater/diagnostic_updater/_update_functions.py
@@ -40,10 +40,10 @@ diagnostic_updater for Python.
 
 import threading
 
+from diagnostic_msgs.msg import DiagnosticStatus
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
 
-from diagnostic_msgs.msg import DiagnosticStatus
 from ._diagnostic_updater import DiagnosticTask
 
 

--- a/diagnostic_updater/diagnostic_updater/_update_functions.py
+++ b/diagnostic_updater/diagnostic_updater/_update_functions.py
@@ -43,6 +43,7 @@ import threading
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
 
+from diagnostic_msgs.msg import DiagnosticStatus
 from ._diagnostic_updater import DiagnosticTask
 
 
@@ -115,14 +116,14 @@ class FrequencyStatus(DiagnosticTask):
             self.hist_indx = (self.hist_indx + 1) % self.params.window_size
 
             if events == 0:
-                stat.summary(b'\x02', 'No events recorded.')
+                stat.summary(DiagnosticStatus.ERRROR, 'No events recorded.')
             elif freq < self.params.freq_bound['min'] * (1 - self.params.tolerance):
-                stat.summary(b'\x01', 'Frequency too low.')
+                stat.summary(DiagnosticStatus.WARN, 'Frequency too low.')
             elif 'max' in self.params.freq_bound and freq > self.params.freq_bound['max'] *\
                  (1 + self.params.tolerance):
-                stat.summary(b'\x01', 'Frequency too high.')
+                stat.summary(DiagnosticStatus.WARN, 'Frequency too high.')
             else:
-                stat.summary(b'\x00', 'Desired frequency met')
+                stat.summary(DiagnosticStatus.OK, 'Desired frequency met')
 
             stat.add('Events in window', '%d' % events)
             stat.add('Events since startup', '%d' % self.count)
@@ -206,18 +207,18 @@ class TimeStampStatus(DiagnosticTask):
     def run(self, stat):
         with self.lock:
 
-            stat.summary(b'\x00', 'Timestamps are reasonable.')
+            stat.summary(DiagnosticStatus.OK, 'Timestamps are reasonable.')
             if not self.deltas_valid:
-                stat.summary(b'\x01', 'No data since last update.')
+                stat.summary(DiagnosticStatus.WARN, 'No data since last update.')
             else:
                 if self.min_delta < self.params.min_acceptable:
-                    stat.summary(b'\x02', 'Timestamps too far in future seen.')
+                    stat.summary(DiagnosticStatus.ERRROR, 'Timestamps too far in future seen.')
                     self.early_count += 1
                 if self.max_delta > self.params.max_acceptable:
-                    stat.summary(b'\x02', 'Timestamps too far in past seen.')
+                    stat.summary(DiagnosticStatus.ERRROR, 'Timestamps too far in past seen.')
                     self.late_count += 1
                 if self.zero_seen:
-                    stat.summary(b'\x02', 'Zero timestamp seen.')
+                    stat.summary(DiagnosticStatus.ERRROR, 'Zero timestamp seen.')
                     self.zero_count += 1
 
             stat.add('Earliest timestamp delay:', '%f' % self.min_delta)
@@ -248,5 +249,5 @@ class Heartbeat(DiagnosticTask):
         DiagnosticTask.__init__(self, 'Heartbeat')
 
     def run(self, stat):
-        stat.summary(b'\x00', 'Alive')
+        stat.summary(DiagnosticStatus.OK, 'Alive')
         return stat

--- a/diagnostic_updater/diagnostic_updater/example.py
+++ b/diagnostic_updater/diagnostic_updater/example.py
@@ -190,7 +190,8 @@ def main():
 
     # You can broadcast a message in all the DiagnosticStatus if your node
     # is in a special state.
-    updater.broadcast(b'\x00', 'Doing important initialization stuff.')
+    updater.broadcast(diagnostic_msgs.msg.DiagnosticStatus.OK,
+                      'Doing important initialization stuff.')
 
     pub1 = node.create_publisher(std_msgs.msg.Bool, 'topic1', 10)
     sleep(2)  # It isn't important if it doesn't take time.

--- a/diagnostic_updater/test/diagnostic_updater_test.py
+++ b/diagnostic_updater/test/diagnostic_updater_test.py
@@ -106,10 +106,14 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         stat[4] = fs.run(stat[4])
         # Should be good, just cleared it.
 
-        self.assertEqual(DiagnosticStatus.WARN, stat[0].level, 'max frequency exceeded but not reported')
-        self.assertEqual(DiagnosticStatus.OK, stat[1].level, 'within max frequency but reported error')
-        self.assertEqual(DiagnosticStatus.OK, stat[2].level, 'within min frequency but reported error')
-        self.assertEqual(DiagnosticStatus.WARN, stat[3].level, 'min frequency exceeded but not reported')
+        self.assertEqual(DiagnosticStatus.WARN, stat[0].level,
+                         'max frequency exceeded but not reported')
+        self.assertEqual(DiagnosticStatus.OK, stat[1].level,
+                         'within max frequency but reported error')
+        self.assertEqual(DiagnosticStatus.OK, stat[2].level,
+                         'within min frequency but reported error')
+        self.assertEqual(DiagnosticStatus.WARN, stat[3].level,
+                         'min frequency exceeded but not reported')
         self.assertEqual(DiagnosticStatus.ERROR, stat[4].level, 'freshly cleared should fail')
         self.assertEqual('', stat[0].name, 'Name should not be set by FrequencyStatus')
         self.assertEqual('FrequencyStatus', fs.getName(), 'Name should be Frequency Status')

--- a/diagnostic_updater/test/diagnostic_updater_test.py
+++ b/diagnostic_updater/test/diagnostic_updater_test.py
@@ -6,11 +6,10 @@
 import time
 import unittest
 
+from diagnostic_msgs.msg import DiagnosticStatus
 from diagnostic_updater import DiagnosticStatusWrapper, DiagnosticTask
 from diagnostic_updater import FrequencyStatus, FrequencyStatusParam
 from diagnostic_updater import TimeStampStatus, Updater
-
-from diagnostic_msgs.msg import DiagnosticStatus
 
 import rclpy
 from rclpy.clock import Clock

--- a/diagnostic_updater/test/diagnostic_updater_test.py
+++ b/diagnostic_updater/test/diagnostic_updater_test.py
@@ -10,6 +10,8 @@ from diagnostic_updater import DiagnosticStatusWrapper, DiagnosticTask
 from diagnostic_updater import FrequencyStatus, FrequencyStatusParam
 from diagnostic_updater import TimeStampStatus, Updater
 
+from diagnostic_msgs.msg import DiagnosticStatus
+
 import rclpy
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
@@ -21,7 +23,7 @@ class ClassFunction(DiagnosticTask):
         DiagnosticTask.__init__(self, 'classFunction')
 
     def run(self, stat):
-        stat.summary(b'\x00', 'Test is running')
+        stat.summary(DiagnosticStatus.OK, 'Test is running')
         stat.add('Value', '%f' % 5)
         stat.add('String', 'Toto')
         stat.add('Floating', 5.55)
@@ -54,7 +56,7 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         stat = DiagnosticStatusWrapper()
 
         message = 'dummy'
-        level = b'\x01'
+        level = DiagnosticStatus.WARN
         stat.summary(level, message)
         self.assertEqual(message, stat.message, 'DiagnosticStatusWrapper::summary failed\
                          to set message')
@@ -105,11 +107,11 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         stat[4] = fs.run(stat[4])
         # Should be good, just cleared it.
 
-        self.assertEqual(b'\x01', stat[0].level, 'max frequency exceeded but not reported')
-        self.assertEqual(b'\x00', stat[1].level, 'within max frequency but reported error')
-        self.assertEqual(b'\x00', stat[2].level, 'within min frequency but reported error')
-        self.assertEqual(b'\x01', stat[3].level, 'min frequency exceeded but not reported')
-        self.assertEqual(b'\x02', stat[4].level, 'freshly cleared should fail')
+        self.assertEqual(DiagnosticStatus.WARN, stat[0].level, 'max frequency exceeded but not reported')
+        self.assertEqual(DiagnosticStatus.OK, stat[1].level, 'within max frequency but reported error')
+        self.assertEqual(DiagnosticStatus.OK, stat[2].level, 'within min frequency but reported error')
+        self.assertEqual(DiagnosticStatus.WARN, stat[3].level, 'min frequency exceeded but not reported')
+        self.assertEqual(DiagnosticStatus.ERRROR, stat[4].level, 'freshly cleared should fail')
         self.assertEqual('', stat[0].name, 'Name should not be set by FrequencyStatus')
         self.assertEqual('FrequencyStatus', fs.getName(), 'Name should be Frequency Status')
 
@@ -132,11 +134,11 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         ts.tick((now.nanoseconds * 1e-9) - 6)
         stat[4] = ts.run(stat[4])
 
-        self.assertEqual(b'\x01', stat[0].level, 'no data should return a warning')
-        self.assertEqual(b'\x02', stat[1].level, 'too far future not reported')
-        self.assertEqual(b'\x00', stat[2].level, 'now not accepted')
-        self.assertEqual(b'\x00', stat[3].level, '4 seconds ago not accepted')
-        self.assertEqual(b'\x02', stat[4].level, 'too far past not reported')
+        self.assertEqual(DiagnosticStatus.WARN, stat[0].level, 'no data should return a warning')
+        self.assertEqual(DiagnosticStatus.ERRROR, stat[1].level, 'too far future not reported')
+        self.assertEqual(DiagnosticStatus.OK, stat[2].level, 'now not accepted')
+        self.assertEqual(DiagnosticStatus.OK, stat[3].level, '4 seconds ago not accepted')
+        self.assertEqual(DiagnosticStatus.ERRROR, stat[4].level, 'too far past not reported')
         self.assertEqual('', stat[0].name, 'Name should not be set by TimeStapmStatus')
         self.assertEqual('Timestamp Status', ts.getName(), 'Name should be Timestamp Status')
 

--- a/diagnostic_updater/test/diagnostic_updater_test.py
+++ b/diagnostic_updater/test/diagnostic_updater_test.py
@@ -110,7 +110,7 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         self.assertEqual(DiagnosticStatus.OK, stat[1].level, 'within max frequency but reported error')
         self.assertEqual(DiagnosticStatus.OK, stat[2].level, 'within min frequency but reported error')
         self.assertEqual(DiagnosticStatus.WARN, stat[3].level, 'min frequency exceeded but not reported')
-        self.assertEqual(DiagnosticStatus.ERRROR, stat[4].level, 'freshly cleared should fail')
+        self.assertEqual(DiagnosticStatus.ERROR, stat[4].level, 'freshly cleared should fail')
         self.assertEqual('', stat[0].name, 'Name should not be set by FrequencyStatus')
         self.assertEqual('FrequencyStatus', fs.getName(), 'Name should be Frequency Status')
 
@@ -134,10 +134,10 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         stat[4] = ts.run(stat[4])
 
         self.assertEqual(DiagnosticStatus.WARN, stat[0].level, 'no data should return a warning')
-        self.assertEqual(DiagnosticStatus.ERRROR, stat[1].level, 'too far future not reported')
+        self.assertEqual(DiagnosticStatus.ERROR, stat[1].level, 'too far future not reported')
         self.assertEqual(DiagnosticStatus.OK, stat[2].level, 'now not accepted')
         self.assertEqual(DiagnosticStatus.OK, stat[3].level, '4 seconds ago not accepted')
-        self.assertEqual(DiagnosticStatus.ERRROR, stat[4].level, 'too far past not reported')
+        self.assertEqual(DiagnosticStatus.ERROR, stat[4].level, 'too far past not reported')
         self.assertEqual('', stat[0].name, 'Name should not be set by TimeStapmStatus')
         self.assertEqual('Timestamp Status', ts.getName(), 'Name should be Timestamp Status')
 

--- a/diagnostic_updater/test/test_diagnostic_status_wrapper.py
+++ b/diagnostic_updater/test/test_diagnostic_status_wrapper.py
@@ -48,8 +48,8 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         self.assertEqual(d.level, DiagnosticStatus.WARN)
         self.assertEqual(d.message, 'warn')
 
-        d.mergeSummary(DiagnosticStatus.ERRROR, 'err')
-        self.assertEqual(d.level, DiagnosticStatus.ERRROR)
+        d.mergeSummary(DiagnosticStatus.ERROR, 'err')
+        self.assertEqual(d.level, DiagnosticStatus.ERROR)
         self.assertEqual(d.message, 'warn; err')
 
     def test_merge_summary_dmsg(self):
@@ -59,9 +59,9 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
         self.assertEqual(d.level, DiagnosticStatus.WARN)
         self.assertEqual(d.message, 'warn')
 
-        m = DiagnosticStatus(level=DiagnosticStatus.ERRROR, message='err')
+        m = DiagnosticStatus(level=DiagnosticStatus.ERROR, message='err')
         d.mergeSummary(m)
-        self.assertEqual(d.level, DiagnosticStatus.ERRROR)
+        self.assertEqual(d.level, DiagnosticStatus.ERROR)
         self.assertEqual(d.message, 'warn; err')
 
     def test_add(self):

--- a/diagnostic_updater/test/test_diagnostic_status_wrapper.py
+++ b/diagnostic_updater/test/test_diagnostic_status_wrapper.py
@@ -13,55 +13,55 @@ class TestDiagnosticStatusWrapper(unittest.TestCase):
 
     def test_init_empty(self):
         d = DiagnosticStatusWrapper()
-        self.assertEqual(d.level, b'\x00')
+        self.assertEqual(d.level, DiagnosticStatus.OK)
         self.assertEqual(d.message, '')
         self.assertEqual(d.values, [])
 
     def test_init_lvl_msg(self):
-        d = DiagnosticStatusWrapper(level=b'\x01', message='test')
-        self.assertEqual(d.level, b'\x01')
+        d = DiagnosticStatusWrapper(level=DiagnosticStatus.WARN, message='test')
+        self.assertEqual(d.level, DiagnosticStatus.WARN)
         self.assertEqual(d.message, 'test')
         self.assertEqual(d.values, [])
 
     def test_summary_lvl_msg(self):
         d = DiagnosticStatusWrapper()
-        d.summary(b'\x01', 'test')
-        self.assertEqual(d.level, b'\x01')
+        d.summary(DiagnosticStatus.WARN, 'test')
+        self.assertEqual(d.level, DiagnosticStatus.WARN)
         self.assertEqual(d.message, 'test')
 
     def test_summary_dmsg(self):
-        d = DiagnosticStatusWrapper(level=b'\x00', message='ok')
-        m = DiagnosticStatus(level=b'\x01', message='warn')
+        d = DiagnosticStatusWrapper(level=DiagnosticStatus.OK, message='ok')
+        m = DiagnosticStatus(level=DiagnosticStatus.WARN, message='warn')
         d.summary(m)
-        self.assertEqual(d.level, b'\x01')
+        self.assertEqual(d.level, DiagnosticStatus.WARN)
         self.assertEqual(d.message, 'warn')
 
     def test_clear_summary(self):
-        d = DiagnosticStatusWrapper(level=b'\x00', message='ok')
+        d = DiagnosticStatusWrapper(level=DiagnosticStatus.OK, message='ok')
         d.clearSummary()
-        self.assertEqual(d.level, b'\x00')
+        self.assertEqual(d.level, DiagnosticStatus.OK)
         self.assertEqual(d.message, '')
 
     def test_merge_summary_lvl_msg(self):
-        d = DiagnosticStatusWrapper(level=b'\x00', message='ok')
-        d.mergeSummary(b'\x01', 'warn')
-        self.assertEqual(d.level, b'\x01')
+        d = DiagnosticStatusWrapper(level=DiagnosticStatus.OK, message='ok')
+        d.mergeSummary(DiagnosticStatus.WARN, 'warn')
+        self.assertEqual(d.level, DiagnosticStatus.WARN)
         self.assertEqual(d.message, 'warn')
 
-        d.mergeSummary(b'\x02', 'err')
-        self.assertEqual(d.level, b'\x02')
+        d.mergeSummary(DiagnosticStatus.ERRROR, 'err')
+        self.assertEqual(d.level, DiagnosticStatus.ERRROR)
         self.assertEqual(d.message, 'warn; err')
 
     def test_merge_summary_dmsg(self):
-        d = DiagnosticStatusWrapper(level=b'\x00', message='ok')
-        m = DiagnosticStatus(level=b'\x01', message='warn')
+        d = DiagnosticStatusWrapper(level=DiagnosticStatus.OK, message='ok')
+        m = DiagnosticStatus(level=DiagnosticStatus.WARN, message='warn')
         d.mergeSummary(m)
-        self.assertEqual(d.level, b'\x01')
+        self.assertEqual(d.level, DiagnosticStatus.WARN)
         self.assertEqual(d.message, 'warn')
 
-        m = DiagnosticStatus(level=b'\x02', message='err')
+        m = DiagnosticStatus(level=DiagnosticStatus.ERRROR, message='err')
         d.mergeSummary(m)
-        self.assertEqual(d.level, b'\x02')
+        self.assertEqual(d.level, DiagnosticStatus.ERRROR)
         self.assertEqual(d.message, 'warn; err')
 
     def test_add(self):


### PR DESCRIPTION
As I mentioned in https://github.com/ros/diagnostics/pull/184, using the values of DiagnosticStatus instead of creating bytes manually is more error-proof.

I'm unsure how to further improve the test suite, as the conversion happens at `status_item.hpp`.