### PR TITLE
[diagnotics_analysis] fix type comparison for python3

### DIFF
--- a/diagnostic_analysis/src/diagnostic_analysis/exporter.py
+++ b/diagnostic_analysis/src/diagnostic_analysis/exporter.py
@@ -112,7 +112,7 @@ class LogExporter:
                 
 
             # Check to see if fields have changed. Add new fields to map
-            if (not [s.key for s in status.values] == self._stats[name]['fields'].keys()):
+            if not [s.key for s in status.values] == list(self._stats[name]['fields'].keys()):
                 for s in status.values:
                     if not s.key in self._stats[name]['fields']:
                         self._stats[name]['fields'][s.key] = len(self._stats[name]['fields'])


### PR DESCRIPTION
In python3, `self._stats[name]['fields'].keys()` returns a `dict_keys` object, so the comparison to a `list` is never `True`.


PS: the default branch of this depo is `indigo-devel` making it the default target for PRs, should it be noetic-devel instead ?