### PR TITLE
[ROS2] Time Diagnostics can be used with Simulated Time

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -45,6 +45,7 @@
 
 #include "rclcpp/publisher.hpp"
 #include "rclcpp/subscription.hpp"
+#include "rclcpp/clock.hpp"
 
 namespace
 {
@@ -140,14 +141,18 @@ public:
    *
    * \param stamp The parameters for the TimeStampStatus class that will be
    * computing statistics.
+   *
+   * \param clock Pointer to a clock instance. If not provided, the default
+   * one will be used
    */
 
   TopicDiagnostic(
     std::string name, diagnostic_updater::Updater & diag,
     const diagnostic_updater::FrequencyStatusParam & freq,
-    const diagnostic_updater::TimeStampStatusParam & stamp)
+    const diagnostic_updater::TimeStampStatusParam & stamp,
+    const rclcpp::Clock::SharedPtr & clock = nullptr)
   : HeaderlessTopicDiagnostic(name, diag, freq),
-    stamp_(stamp),
+    stamp_(stamp, clock),
     error_logger_(rclcpp::get_logger("TopicDiagnostic_error_logger"))
   {
     addTask(&stamp_);

--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -150,7 +150,7 @@ public:
     std::string name, diagnostic_updater::Updater & diag,
     const diagnostic_updater::FrequencyStatusParam & freq,
     const diagnostic_updater::TimeStampStatusParam & stamp,
-    const rclcpp::Clock::SharedPtr & clock = nullptr)
+    const rclcpp::Clock::SharedPtr & clock = std::make_shared<rclcpp::Clock>())
   : HeaderlessTopicDiagnostic(name, diag, freq),
     stamp_(stamp, clock),
     error_logger_(rclcpp::get_logger("TopicDiagnostic_error_logger"))

--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -43,9 +43,9 @@
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_updater/update_functions.hpp"
 
+#include "rclcpp/clock.hpp"
 #include "rclcpp/publisher.hpp"
 #include "rclcpp/subscription.hpp"
-#include "rclcpp/clock.hpp"
 
 namespace
 {

--- a/diagnostic_updater/include/diagnostic_updater/update_functions.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.hpp
@@ -278,8 +278,11 @@ public:
    * \brief Constructs the TimeStampStatus with the given parameters.
    */
 
-  TimeStampStatus(const TimeStampStatusParam & params, std::string name)
-  : DiagnosticTask(name), params_(params)
+  TimeStampStatus(
+    const TimeStampStatusParam & params,
+    std::string name,
+    const rclcpp::Clock::SharedPtr & clock = nullptr)
+  : DiagnosticTask(name), params_(params), clock_ptr_(clock)
   {
     init();
   }
@@ -289,8 +292,10 @@ public:
    *        Uses a default diagnostic task name of "Timestamp Status".
    */
 
-  explicit TimeStampStatus(const TimeStampStatusParam & params)
-  : DiagnosticTask("Timestamp Status"), params_(params)
+  explicit TimeStampStatus(
+    const TimeStampStatusParam & params,
+    const rclcpp::Clock::SharedPtr & clock = nullptr)
+  : DiagnosticTask("Timestamp Status"), params_(params), clock_ptr_(clock)
   {
     init();
   }
@@ -300,8 +305,8 @@ public:
    *        Uses a default diagnostic task name of "Timestamp Status".
    */
 
-  TimeStampStatus()
-  : DiagnosticTask("Timestamp Status") {init();}
+  explicit TimeStampStatus(const rclcpp::Clock::SharedPtr & clock = nullptr)
+  : DiagnosticTask("Timestamp Status"), clock_ptr_(clock) {init();}
 
   /**
    * \brief Signals an event. Timestamp stored as a double.
@@ -317,7 +322,9 @@ public:
     if (stamp == 0) {
       zero_seen_ = true;
     } else {
-      double delta = rclcpp::Clock().now().seconds() - stamp;
+      const double curr_stamp =
+        clock_ptr_ ? clock_ptr_->now().seconds() : rclcpp::Clock().now().seconds();
+      const double delta = curr_stamp - stamp;
 
       if (!deltas_valid_ || delta > max_delta_) {
         max_delta_ = delta;
@@ -390,6 +397,7 @@ private:
   double max_delta_;
   double min_delta_;
   bool deltas_valid_;
+  const rclcpp::Clock::SharedPtr clock_ptr_;
   std::mutex lock_;
 };
 

--- a/diagnostic_updater/include/diagnostic_updater/update_functions.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.hpp
@@ -281,7 +281,7 @@ public:
   TimeStampStatus(
     const TimeStampStatusParam & params,
     std::string name,
-    const rclcpp::Clock::SharedPtr & clock = nullptr)
+    const rclcpp::Clock::SharedPtr & clock = std::make_shared<rclcpp::Clock>())
   : DiagnosticTask(name), params_(params), clock_ptr_(clock)
   {
     init();
@@ -294,7 +294,7 @@ public:
 
   explicit TimeStampStatus(
     const TimeStampStatusParam & params,
-    const rclcpp::Clock::SharedPtr & clock = nullptr)
+    const rclcpp::Clock::SharedPtr & clock = std::make_shared<rclcpp::Clock>())
   : DiagnosticTask("Timestamp Status"), params_(params), clock_ptr_(clock)
   {
     init();
@@ -305,7 +305,8 @@ public:
    *        Uses a default diagnostic task name of "Timestamp Status".
    */
 
-  explicit TimeStampStatus(const rclcpp::Clock::SharedPtr & clock = nullptr)
+  explicit TimeStampStatus(
+    const rclcpp::Clock::SharedPtr & clock = std::make_shared<rclcpp::Clock>())
   : DiagnosticTask("Timestamp Status"), clock_ptr_(clock) {init();}
 
   /**
@@ -322,9 +323,7 @@ public:
     if (stamp == 0) {
       zero_seen_ = true;
     } else {
-      const double curr_stamp =
-        clock_ptr_ ? clock_ptr_->now().seconds() : rclcpp::Clock().now().seconds();
-      const double delta = curr_stamp - stamp;
+      const double delta = clock_ptr_->now().seconds() - stamp;
 
       if (!deltas_valid_ || delta > max_delta_) {
         max_delta_ = delta;

--- a/diagnostic_updater/include/diagnostic_updater/update_functions.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/update_functions.hpp
@@ -38,6 +38,7 @@
 #define DIAGNOSTIC_UPDATER__UPDATE_FUNCTIONS_HPP_
 
 #include <math.h>
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Opening the PR again, now targeting to ros2-devel.

This PR adds the possibility to provide an external `rclcpp::Clock` instance to the `TopicDiagnostic` and the `TimeStampStatus` objects at construction time.
This way the `TimeStampStatus::tick` method (and the `TopicDiagnostic::tick` one) can compare the input time to different clock sources (e.g. the one by Gazebo), depending on the rclcpp::Clock instance it was provided with.