### PR TITLE
Return the actual future from async_send_request

### DIFF
--- a/self_test/src/run_selftest.cpp
+++ b/self_test/src/run_selftest.cpp
@@ -91,7 +91,7 @@ public:
           }
         }
       };
-    return client_->async_send_request(request, response_received_callback);
+    return client_->async_send_request(request, response_received_callback).future;
   }
 
 private:


### PR DESCRIPTION
Recent changes to rclcpp in Rolling make it return a structure
rather than just the future.  In order to maintain this test,
return the actual future.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>