### PR TITLE
Use node clock for diagnostic_aggregator and diagnostic_updater

### DIFF
--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -63,7 +63,7 @@ Aggregator::Aggregator()
   logger_(rclcpp::get_logger("Aggregator")),
   pub_rate_(1.0),
   history_depth_(1000),
-  clock_(new rclcpp::Clock()),
+  clock_(n_->get_clock()),
   base_path_("/")
 {
   RCLCPP_DEBUG(logger_, "constructor");

--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -366,6 +366,7 @@ public:
   explicit Updater(NodeT node, double period = 1.0)
   : Updater(
       node->get_node_base_interface(),
+      node->get_node_clock_interface(),
       node->get_node_logging_interface(),
       node->get_node_parameters_interface(),
       node->get_node_timers_interface(),
@@ -375,6 +376,7 @@ public:
 
   Updater(
     std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> base_interface,
+    std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface> clock_interface,
     std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface> logging_interface,
     std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
     std::shared_ptr<rclcpp::node_interfaces::NodeTimersInterface> timers_interface,
@@ -383,7 +385,7 @@ public:
   : verbose_(false),
     base_interface_(base_interface),
     timers_interface_(timers_interface),
-    clock_(std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)),
+    clock_(clock_interface->get_clock()),
     period_(rclcpp::Duration::from_nanoseconds(period * 1e9)),
     publisher_(
       rclcpp::create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
@@ -574,7 +576,7 @@ private:
     }
     diagnostic_msgs::msg::DiagnosticArray msg;
     msg.status = status_vec;
-    msg.header.stamp = rclcpp::Clock().now();
+    msg.header.stamp = clock_->now();
     publisher_->publish(msg);
   }
 


### PR DESCRIPTION
## Overview

I found there is a bug when using `diagnostic_aggregator` and `diagnostic_updater` with `use_sim_time=true`.
To fix this, I changed to use node's clock.

FYI: As another way, I also tried simply to use `RCL_ROS_TIME` like `clock_(new rclcpp::Clock(RCL_ROS_TIME))`, but it had no effect.

## How to reproduce the problem

Distribution: ROS Galactic

```sh
git clone https://github.com/kenji-miyake/test-diagnostics-sim-time.git
cd test-diagnostics-sim-time
source /opt/ros/galactic/setup.bash
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
source install/setup.bash

# Terminal 1
ros2 launch test_diagnostics test.launch.xml use_sim_time:=true

# Terminal 2
ros2 topic echo /clock

# Terminal 3
ros2 topic echo /diagnostics
# sim time isn't reflected to diagnostic_updater

# Terminal 4
ros2 topic echo /diagnostics_agg --no-arr
# sim time isn't reflected to diagnostic_aggregator
```

## How to test this PR

```sh
git clone https://github.com/kenji-miyake/test-diagnostics-sim-time.git
cd test-diagnostics-sim-time
git clone https://github.com/tier4/diagnostics.git -b fix-sim-time-bug
source /opt/ros/galactic/setup.bash
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
source install/setup.bash

# Terminal 1
ros2 launch test_diagnostics test.launch.xml use_sim_time:=true

# Terminal 2
ros2 topic echo /clock

# Terminal 3
ros2 topic echo /diagnostics
# sim time is reflected to diagnostic_updater

# Terminal 4
ros2 topic echo /diagnostics_agg --no-arr
# sim time is reflected to diagnostic_aggregator
```