### PR TITLE
Replace colcon-mixin-name in the GitHub action.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,12 @@ jobs:
             self_test
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
-          colcon-mixin-name: coverage-gcc
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
colcon-mixin-name no longer exists in action-ros-ci.  Instead,
use colcon-defaults with the appropriate snippet, which should
work better.  This will get rid of a warning when GitHub actions
are run.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>