### PR TITLE
[ROS2][Galactic backport] Use node clock for diagnostic_aggregator and diagnostic_updater (#210)

### DIFF
--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -63,7 +63,7 @@ Aggregator::Aggregator()
   logger_(rclcpp::get_logger("Aggregator")),
   pub_rate_(1.0),
   history_depth_(1000),
-  clock_(new rclcpp::Clock()),
+  clock_(n_->get_clock()),
   base_path_("/")
 {
   RCLCPP_DEBUG(logger_, "constructor");

--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -366,6 +366,7 @@ public:
   explicit Updater(NodeT node, double period = 1.0)
   : Updater(
       node->get_node_base_interface(),
+      node->get_node_clock_interface(),
       node->get_node_logging_interface(),
       node->get_node_parameters_interface(),
       node->get_node_timers_interface(),
@@ -375,6 +376,7 @@ public:
 
   Updater(
     std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> base_interface,
+    std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface> clock_interface,
     std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface> logging_interface,
     std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
     std::shared_ptr<rclcpp::node_interfaces::NodeTimersInterface> timers_interface,
@@ -383,7 +385,7 @@ public:
   : verbose_(false),
     base_interface_(base_interface),
     timers_interface_(timers_interface),
-    clock_(std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)),
+    clock_(clock_interface->get_clock()),
     period_(rclcpp::Duration::from_nanoseconds(period * 1e9)),
     publisher_(
       rclcpp::create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
@@ -574,7 +576,7 @@ private:
     }
     diagnostic_msgs::msg::DiagnosticArray msg;
     msg.status = status_vec;
-    msg.header.stamp = rclcpp::Clock().now();
+    msg.header.stamp = clock_->now();
     publisher_->publish(msg);
   }
 


### PR DESCRIPTION
backport of #210 

This breaks API/ABI, but following this comment, I'd like to ask maintainers whether this can be merged.
https://github.com/ros/diagnostics/pull/210#issuecomment-946703016

@Karsten1987 Could you review this, please? :pray: 