### PR TITLE
[ROS2][Galactic backport] Return the actual future from async_send_request (#209)

### DIFF
--- a/self_test/src/run_selftest.cpp
+++ b/self_test/src/run_selftest.cpp
@@ -91,7 +91,7 @@ public:
           }
         }
       };
-    return client_->async_send_request(request, response_received_callback);
+    return client_->async_send_request(request, response_received_callback).future;
   }
 
 private:


### PR DESCRIPTION
This is a backport PR to fix test error at https://github.com/ros/diagnostics/runs/3947786231?check_suite_focus=true in #212.
@clalancette could you review this?