### PR TITLE
[ROS2] Use node clock in FrequencyStatus diagnostic

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -91,12 +91,16 @@ public:
    *
    * \param freq The parameters for the FrequencyStatus class that will be
    * computing statistics.
+   *
+   * \param clock Pointer to a clock instance. If not provided, the default
+   * one will be used
    */
 
   HeaderlessTopicDiagnostic(
     std::string name, diagnostic_updater::Updater & diag,
-    const diagnostic_updater::FrequencyStatusParam & freq)
-  : CompositeDiagnosticTask(name + " topic status"), freq_(freq)
+    const diagnostic_updater::FrequencyStatusParam & freq,
+    const rclcpp::Clock::SharedPtr & clock = std::make_shared<rclcpp::Clock>())
+  : CompositeDiagnosticTask(name + " topic status"), freq_(freq, clock)
   {
     addTask(&freq_);
     diag.add(*this);
@@ -151,7 +155,7 @@ public:
     const diagnostic_updater::FrequencyStatusParam & freq,
     const diagnostic_updater::TimeStampStatusParam & stamp,
     const rclcpp::Clock::SharedPtr & clock = std::make_shared<rclcpp::Clock>())
-  : HeaderlessTopicDiagnostic(name, diag, freq),
+  : HeaderlessTopicDiagnostic(name, diag, freq, clock),
     stamp_(stamp, clock),
     error_logger_(rclcpp::get_logger("TopicDiagnostic_error_logger"))
   {


### PR DESCRIPTION
This PR adds the possibility to provide an external `rclcpp::Clock` instance to the `HeaderlessTopicDiagnostic` and the `FrequencyStatus` objects at construction time.
This way the `FrequencyStatus` diagnostic will provide accurate results even in case the clock is not running in real time (e.g. when Gazebo's Real Time Factor is not 1).