### PR TITLE
Check if parameter is already declared to avoid re-declaring it.

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -394,8 +394,16 @@ public:
     node_name_(base_interface->get_name()),
     warn_nohwid_done_(false)
   {
-    period = parameters_interface->declare_parameter(
-      "diagnostic_updater.period", rclcpp::ParameterValue(period)).get<double>();
+    constexpr const char * period_param_name = "diagnostic_updater.period";
+    rclcpp::ParameterValue period_param;
+    try {
+      period_param = parameters_interface->declare_parameter(
+        period_param_name, rclcpp::ParameterValue(
+          period));
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException & exc) {
+      period_param = parameters_interface->get_parameter(period_param_name).get_parameter_value();
+    }
+    period = period_param.get<double>();
     period_ = rclcpp::Duration::from_nanoseconds(period * 1e9);
 
     reset_timer();

--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -396,12 +396,11 @@ public:
   {
     constexpr const char * period_param_name = "diagnostic_updater.period";
     rclcpp::ParameterValue period_param;
-    try {
-      period_param = parameters_interface->declare_parameter(
-        period_param_name, rclcpp::ParameterValue(
-          period));
-    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException & exc) {
+    if (parameters_interface->has_parameter(period_param_name)) {
       period_param = parameters_interface->get_parameter(period_param_name).get_parameter_value();
+    } else {
+      period_param = parameters_interface->declare_parameter(
+        period_param_name, rclcpp::ParameterValue(period));
     }
     period = period_param.get<double>();
     period_ = rclcpp::Duration::from_nanoseconds(period * 1e9);


### PR DESCRIPTION
A parameter can only be declared once. When implementing a LicecycleNode one
would normally do all the initialization in `on_configure()` and the cleanup,
deinitialization in the `on_cleanup` method. Furthermore, these transitions
could potentially be called multiple times, depending on how the node is t
ransitioned from the lifecycles are triggered. However, this approach doesn't
currently work well with Diagnostics since, in the constructor, of
`diagnostic_updater::Updater` it's declaring a static parameter without checking
whether that parameter has already been declared. In subsequent calls to
`on_configure` (and thus, if Diagnostics are initialized there, in subsequent
calls to the `Updater` constructor, this results in the following message:

```
Original error: parameter 'diagnostic_updater.period' has already been declared
```

To avoid this, until the Foxy version, the wrapper code could explicitly call
`undeclare_parameter` on the parameter that the `Updater` is declaring, but as
of Galactic, undeclaring a static parameter is not allowed anymore. See e.g.,
https://github.com/ros2/rclcpp/pull/1850.

In this commit, I'm checking explicitly if the parameter has already been
registered and if so, I'm just reading its value before attempting to re-declare
it.
