### PR TITLE
Fix Python3 port of hd_monitor.py

### DIFF
--- a/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/hd_monitor.py
+++ b/diagnostic_common_diagnostics/src/diagnostic_common_diagnostics/hd_monitor.py
@@ -64,15 +64,15 @@ def get_hddtemp_data(hostname='localhost', port=7634):
     try:
         hd_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         hd_sock.connect((hostname, port))
-        sock_data = ''
+        sock_data = b''
         while True:
             newdat = hd_sock.recv(1024)
             if len(newdat) == 0:
                 break
-            sock_data = sock_data + str(newdat)
+            sock_data = sock_data + newdat
         hd_sock.close()
 
-        sock_vals = sock_data.split('|')
+        sock_vals = sock_data.decode().split('|')
 
         # Format of output looks like ' | DRIVE | MAKE | TEMP | '
         idx = 0


### PR DESCRIPTION
The data returned from a socket is `bytes`. So to properly deal with
this data we'd have to concatenate as bytes and decode to string at the
end.

The old (wrong) way of concatenating results in some stray `'b'`
characters showing up in the drive names.