### PR TITLE
Fix diagnostics Updater constructor NodeHandle documentation

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.h
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.h
@@ -368,8 +368,10 @@ namespace diagnostic_updater
       /**
        * \brief Constructs an updater class.
        *
-       * \param h Node handle from which to get the diagnostic_period
+       * \param h Node handle used to publish the diagnostics messages.
+       * \param ph Node handle from which to get the diagnostic_period
        * parameter.
+       * \param node_name Name of the node used in the messages.
        */
     Updater(ros::NodeHandle h = ros::NodeHandle(), ros::NodeHandle ph = ros::NodeHandle("~"), std::string node_name = ros::this_node::getName()) : private_node_handle_(ph), node_handle_(h), node_name_(node_name)
     {


### PR DESCRIPTION
Previously the documentation mistakenly stated the argument `h` was used for getting the `diagnostic_period` parameter. I fixed the documentation.