### PR TITLE
Use python3-psutil instead of python-psutil

### DIFF
--- a/diagnostic_common_diagnostics/package.xml
+++ b/diagnostic_common_diagnostics/package.xml
@@ -27,7 +27,7 @@
   <exec_depend>hddtemp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>tf</exec_depend>
-  <exec_depend>python-psutil</exec_depend>
+  <exec_depend>python3-psutil</exec_depend>
   <exec_depend>ntpdate</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
The [python-psutil](https://github.com/ros/rosdistro/blob/2e2fb76c7a83065cf322e0fd0a1dd04a93a2222e/rosdep/python.yaml#L3518-L3537) key is for the Python 2 package, while ROS 2 uses Python 3 exclusively.

Here's the Python3 key: https://github.com/ros/rosdistro/blob/2e2fb76c7a83065cf322e0fd0a1dd04a93a2222e/rosdep/python.yaml#L8160-L8175