### PR TITLE
Fix package format error

### DIFF
--- a/diagnostic_common_diagnostics/package.xml
+++ b/diagnostic_common_diagnostics/package.xml
@@ -1,4 +1,6 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>diagnostic_common_diagnostics</name>
   <version>1.9.3</version>
   <description>diagnostic_common_diagnostics</description>
@@ -12,7 +14,8 @@
   <url type="website">http://ros.org/wiki/diagnostic_common_diagnostics</url>
 <!-- <url type="bugtracker"></url> -->
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>diagnostic_updater</exec_depend>
@@ -29,6 +32,6 @@
   <test_depend>ament_cmake_lint_cmake</test_depend>
 
   <export>
-    <architecture_independent/>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
Hi, there. I encountered the following error while building diagnostics on the branch Humble and found that it's due to the old version of _package.xml_ in diagnostic_common_diagnostics. How about modifying it to catch up with Galactic? I've checked the building works for ROS2 Humble with this PR.

```txt
❯ colcon build --packages-select diagnostic_common_diagnostics
Starting >>> diagnostic_common_diagnostics
--- stderr: diagnostic_common_diagnostics
Error parsing '/home/circle/pcd-example/src/diagnostics/diagnostic_common_diagnostics/package.xml':
Traceback (most recent call last):
  File "/opt/ros2/humble/share/ament_cmake_core/cmake/core/package_xml_2_cmake.py", line 150, in <module>
    main()
  File "/opt/ros2/humble/share/ament_cmake_core/cmake/core/package_xml_2_cmake.py", line 53, in main
    raise e
  File "/opt/ros2/humble/share/ament_cmake_core/cmake/core/package_xml_2_cmake.py", line 49, in main
    package = parse_package_string(
  File "/usr/lib/python3.10/site-packages/catkin_pkg/package.py", line 786, in parse_package_string
    raise InvalidPackage('Error(s):%s' % (''.join(['\n- %s' % e for e in errors])), filename)
catkin_pkg.package.InvalidPackage: Error(s) in package '/home/circle/pcd-example/src/diagnostics/diagnostic_common_diagnostics/package.xml':
Error(s):
- The manifest of package "diagnostic_common_diagnostics" (with format version 1) must not contain the following tags: exec_depend
- Either update to a newer format or replace <exec_depend> tags with <run_depend> tags.
CMake Error at /opt/ros2/humble/share/ament_cmake_core/cmake/core/ament_package_xml.cmake:95 (message):
  execute_process(/usr/bin/python3.10
  /opt/ros2/humble/share/ament_cmake_core/cmake/core/package_xml_2_cmake.py
  /home/circle/pcd-example/src/diagnostics/diagnostic_common_diagnostics/package.xml
  /home/circle/pcd-example/build/diagnostic_common_diagnostics/ament_cmake_core/package.cmake)
  returned error code 1
Call Stack (most recent call first):
  /opt/ros2/humble/share/ament_cmake_core/cmake/core/ament_package_xml.cmake:49 (_ament_package_xml)
  /opt/ros2/humble/share/ament_cmake_python/cmake/ament_python_install_package.cmake:60 (ament_package_xml)
  /opt/ros2/humble/share/ament_cmake_python/cmake/ament_python_install_package.cmake:39 (_ament_cmake_python_install_package)
  CMakeLists.txt:10 (ament_python_install_package)
```


