### PR TITLE
Fix/ros2 no rclpy in cmakelists

### DIFF
--- a/diagnostic_common_diagnostics/CMakeLists.txt
+++ b/diagnostic_common_diagnostics/CMakeLists.txt
@@ -5,8 +5,6 @@ project(diagnostic_common_diagnostics)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
-find_package(rclpy REQUIRED)
-
 ament_python_install_package(${PROJECT_NAME})
 
 install(PROGRAMS


### PR DESCRIPTION
This should avoid errors like https://build.ros2.org/job/Rbin_uJ64__diagnostic_common_diagnostics__ubuntu_jammy_amd64__binary/4/console#console-section-1