### PR TITLE
Fix two code-analyser bugs

### DIFF
--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -84,12 +84,9 @@ void Aggregator::checkTimestamp(const diagnostic_msgs::DiagnosticArray::ConstPtr
       stamp_warn += ", ";
     stamp_warn += it->name;
   }
-  
-  if (!ros_warnings_.count(stamp_warn))
-  {
-    ROS_WARN("%s", stamp_warn.c_str());
-    ros_warnings_.insert(stamp_warn);
-  }
+
+  auto result = ros_warnings_.insert(stamp_warn);
+  ROS_WARN_COND(result.second, "%s", stamp_warn.c_str());
 }
 
 void Aggregator::diagCallback(const diagnostic_msgs::DiagnosticArray::ConstPtr& diag_msg)

--- a/diagnostic_aggregator/src/aggregator_node.cpp
+++ b/diagnostic_aggregator/src/aggregator_node.cpp
@@ -62,6 +62,5 @@ int main(int argc, char **argv)
   }
   
   exit(0);
-  return 0;
 }
   


### PR DESCRIPTION
We have a static code analyser running and it triggered on these two statements.

The `return 0` can never be reached. 

And one should only invert booleans with `!`. Not integers. The `std::set` used has an `.insert` option which returns if it was actually added. So using that instead.