### PR TITLE
Use default implementation for copy constructor

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_status_wrapper.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_status_wrapper.hpp
@@ -79,7 +79,7 @@ public:
    * nothing.
    * \param other Reference to object to copy
    */
-  explicit DiagnosticStatusWrapper(const DiagnosticStatusWrapper & other);
+  explicit DiagnosticStatusWrapper(const DiagnosticStatusWrapper & other) = default;
 
   /**
    * \brief Fills out the level and message fields of the DiagnosticStatus.


### PR DESCRIPTION
Copy constructor definition is missing. I added the default one.