### PR TITLE
Add Christian Henkel (ct2034) as maintainer for ROS 2 Diagnostics

### DIFF
--- a/diagnostic_aggregator/package.xml
+++ b/diagnostic_aggregator/package.xml
@@ -6,6 +6,7 @@
   <description>diagnostic_aggregator</description>
   <maintainer email="namniart@gmail.com">Austin Hendrix</maintainer>
   <maintainer email="brice.rebsamen@gmail.com">Brice Rebsamen</maintainer>
+  <maintainer email="Christian.Henkel2@de.bosch.com">Christian Henkel</maintainer>
   <maintainer email="ralph.lange@de.bosch.com">Ralph Lange</maintainer>
 
   <license>BSD-3-Clause</license>

--- a/diagnostic_common_diagnostics/package.xml
+++ b/diagnostic_common_diagnostics/package.xml
@@ -6,6 +6,7 @@
   <description>diagnostic_common_diagnostics</description>
   <maintainer email="namniart@gmail.com">Austin Hendrix</maintainer>
   <maintainer email="brice.rebsamen@gmail.com">Brice Rebsamen</maintainer>
+  <maintainer email="Christian.Henkel2@de.bosch.com">Christian Henkel</maintainer>
   <maintainer email="ralph.lange@de.bosch.com">Ralph Lange</maintainer>
 
   <license>BSD-3-Clause</license>

--- a/diagnostic_updater/package.xml
+++ b/diagnostic_updater/package.xml
@@ -6,6 +6,7 @@
   <description>diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.</description>
   <maintainer email="namniart@gmail.com">Austin Hendrix</maintainer>
   <maintainer email="brice.rebsamen@gmail.com">Brice Rebsamen</maintainer>
+  <maintainer email="Christian.Henkel2@de.bosch.com">Christian Henkel</maintainer>
   <maintainer email="ralph.lange@de.bosch.com">Ralph Lange</maintainer>
 
   <license>BSD-3-Clause</license>

--- a/diagnostics/package.xml
+++ b/diagnostics/package.xml
@@ -6,6 +6,7 @@
   <description>diagnostics</description>
   <maintainer email="namniart@gmail.com">Austin Hendrix</maintainer>
   <maintainer email="brice.rebsamen@gmail.com">Brice Rebsamen</maintainer>
+  <maintainer email="Christian.Henkel2@de.bosch.com">Christian Henkel</maintainer>
   <maintainer email="ralph.lange@de.bosch.com">Ralph Lange</maintainer>
 
   <license>BSD-3-Clause</license>

--- a/self_test/package.xml
+++ b/self_test/package.xml
@@ -6,6 +6,7 @@
   <description>self_test</description>
   <maintainer email="namniart@gmail.com">Austin Hendrix</maintainer>
   <maintainer email="brice.rebsamen@gmail.com">Brice Rebsamen</maintainer>
+  <maintainer email="Christian.Henkel2@de.bosch.com">Christian Henkel</maintainer>
   <maintainer email="ralph.lange@de.bosch.com">Ralph Lange</maintainer>
 
   <license>BSD-3-Clause</license>


### PR DESCRIPTION
Please add Christian Henkel (@ct2034) as maintainer of ROS 2 Diagnostics on the part of Bosch. I would like to remain co-maintainer as proxy for Christian. He has already done the majority of the maintenance work in the last months.