### PR TITLE
Deleting copy constructor

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_status_wrapper.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_status_wrapper.hpp
@@ -79,7 +79,7 @@ public:
    * nothing.
    * \param other Reference to object to copy
    */
-  explicit DiagnosticStatusWrapper(const DiagnosticStatusWrapper & other) = default;
+  explicit DiagnosticStatusWrapper(const DiagnosticStatusWrapper & other) = delete;
 
   /**
    * \brief Fills out the level and message fields of the DiagnosticStatus.

--- a/diagnostic_updater/test/diagnostic_status_wrapper_test.cpp
+++ b/diagnostic_updater/test/diagnostic_status_wrapper_test.cpp
@@ -65,17 +65,6 @@ TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperSummaryf) {
   EXPECT_EQ(dsw.values.size(), 0u);
 }
 
-// TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperCopyConstructor) {
-//   // A DiagnosticStatusWrapper initialized from another should have the same
-//   // values.
-//   diagnostic_updater::DiagnosticStatusWrapper dsw;
-//   dsw.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Test");
-//   diagnostic_updater::DiagnosticStatusWrapper dsw_copy(dsw);
-//   EXPECT_EQ(dsw_copy.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
-//   EXPECT_EQ(dsw_copy.message, "Test");
-//   EXPECT_EQ(dsw_copy.values.size(), 0u);
-// }
-
 TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperClearSummary) {
   // A DiagnosticStatusWrapper should be empty after calling clearSummary().
   diagnostic_updater::DiagnosticStatusWrapper dsw;

--- a/diagnostic_updater/test/diagnostic_status_wrapper_test.cpp
+++ b/diagnostic_updater/test/diagnostic_status_wrapper_test.cpp
@@ -65,16 +65,16 @@ TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperSummaryf) {
   EXPECT_EQ(dsw.values.size(), 0u);
 }
 
-TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperCopyConstructor) {
-  // A DiagnosticStatusWrapper initialized from another should have the same
-  // values.
-  diagnostic_updater::DiagnosticStatusWrapper dsw;
-  dsw.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Test");
-  diagnostic_updater::DiagnosticStatusWrapper dsw_copy(dsw);
-  EXPECT_EQ(dsw_copy.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
-  EXPECT_EQ(dsw_copy.message, "Test");
-  EXPECT_EQ(dsw_copy.values.size(), 0u);
-}
+// TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperCopyConstructor) {
+//   // A DiagnosticStatusWrapper initialized from another should have the same
+//   // values.
+//   diagnostic_updater::DiagnosticStatusWrapper dsw;
+//   dsw.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Test");
+//   diagnostic_updater::DiagnosticStatusWrapper dsw_copy(dsw);
+//   EXPECT_EQ(dsw_copy.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+//   EXPECT_EQ(dsw_copy.message, "Test");
+//   EXPECT_EQ(dsw_copy.values.size(), 0u);
+// }
 
 TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperClearSummary) {
   // A DiagnosticStatusWrapper should be empty after calling clearSummary().


### PR DESCRIPTION
Judging by this comment
```
   * Defined and marked explicit so that you don't accidentally use a
   * function<void(DiagnosticStatusWrapper)> where a function<void(DiagnosticStatusWrapper &)>
   * is needed. Otherwise, it's easy to accidentally create a DiagnosticTask that silently does
   * nothing.
``` 
from https://github.com/ct2034/diagnostics/blob/2707b64905b1312783b8c91caaa16418a7ad0376/diagnostic_updater/include/diagnostic_updater/diagnostic_status_wrapper.hpp#L76, it is a good idea **not** to implement the copy constructor here. 
It was removed by https://github.com/ros/diagnostics/pull/285, do you @jordan-palacios have a concrete use case where you need a copy constructor?