### PR TITLE
Replace Clock().now() to node.get_clock().now() in diagnostic_updater.py

### DIFF
--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -42,7 +42,6 @@ import threading
 
 from diagnostic_msgs.msg import DiagnosticArray
 from diagnostic_msgs.msg import DiagnosticStatus
-from rclpy.clock import Clock
 
 from ._diagnostic_status_wrapper import DiagnosticStatusWrapper
 
@@ -239,7 +238,6 @@ class Updater(DiagnosticTaskVector):
         self.node = node
         self.publisher = self.node.create_publisher(
             DiagnosticArray, '/diagnostics', 1)
-        self.clock = Clock()
         self.period_parameter = 'diagnostic_updater.period'
         self.__period = self.node.declare_parameter(
             self.period_parameter, period).value
@@ -350,7 +348,7 @@ class Updater(DiagnosticTaskVector):
         if not type(msg) is list:
             msg = [msg]
 
-        now = self.clock.now()
+        now = self.node.get_clock().now()
         da = DiagnosticArray()
         da.header.stamp = now.to_msg()  # Add timestamp for ROS 0.10
         for stat in msg:
@@ -362,7 +360,6 @@ class Updater(DiagnosticTaskVector):
             db.values = stat.values
             db.level = stat.level
             da.status.append(db)
-
         self.publisher.publish(da)
 
     def addedTaskCallback(self, task):


### PR DESCRIPTION
### Description
In this PR, the `Clock` import in the diagnostic_updater.py has been replaced with `node.get_clock()`. 
This ensures that the correct `ROS_TIME` is used when the `use_sim_time` parameter is set in the `ros2 node`.

### Environment
ros 2 : Humble

### Ref

* https://answers.ros.org/question/321536/replacement-for-rospytimenow-in-ros2/
* https://design.ros2.org/articles/clock_and_time.html

### Verifying the Changes

* Terminal1 

```bash
ros2 launch gazebo_ros gazebo.launch.py
```

* Terminal2

```bash
ros2 run diagnostic_updater example.py --ros-args -p use_sim_time:=true # or false
```

* Terminal3

```bash
ros2 topic echo /diagnostics --field header.stamp.sec
```

#### Before
  header.stamp is `System Time` regardless of `use_sim_time`.

#### After
   header.stamp is `ROS Time` when `use_sim_time` is true. 


