### PR TITLE
Porting cpu monitor to ROS2

### DIFF
--- a/diagnostic_common_diagnostics/CMakeLists.txt
+++ b/diagnostic_common_diagnostics/CMakeLists.txt
@@ -22,6 +22,10 @@ if(BUILD_TESTING)
         test_ntp_monitor
         test/systemtest/test_ntp_monitor.py
         TIMEOUT 10)
+    ament_add_pytest_test(
+        test_cpu_monitor
+        test/systemtest/test_cpu_monitor.py
+        TIMEOUT 10)
 endif()
 
 ament_package()

--- a/diagnostic_common_diagnostics/CMakeLists.txt
+++ b/diagnostic_common_diagnostics/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(ament_cmake_python REQUIRED)
 ament_python_install_package(${PROJECT_NAME})
 
 install(PROGRAMS
+    ${PROJECT_NAME}/cpu_monitor.py
     ${PROJECT_NAME}/ntp_monitor.py
     DESTINATION lib/${PROJECT_NAME}
 )

--- a/diagnostic_common_diagnostics/README.md
+++ b/diagnostic_common_diagnostics/README.md
@@ -8,11 +8,20 @@ Currently only the NTP monitor is ported to ROS2.
 # Nodes
 
 ## ntp_monitor.py
-Runs 'ntpdate' to check if the system clock is synchronized with the NTP server. 
+Runs 'ntpdate' to check if the system clock is synchronized with the NTP server.
 * If the offset is smaller than `offset-tolerance`, an `OK` status will be published.
 * If the offset is larger than the configured `offset-tolerance`, a `WARN` status will be published,
 * if it is bigger than `error-offset-tolerance`, an `ERROR` status will be published.
 * If there was an error running `ntpdate`, an `ERROR` status will be published.
+
+## cpu_monitor.py
+The `cpu_monitor` module allows users to monitor the CPU usage of their system in real-time.
+It publishes the usage percentage in a diagnostic message.
+
+* Name of the node is "cpu_monitor_" + hostname.
+* Uses the following args:
+  * warning_percentage: If the CPU usage is > warning_percentage, a WARN status will be publised.
+  * window: the maximum length of the used collections.deque for queuing CPU readings.
 
 ### Published Topics
 #### /diagnostics
@@ -20,7 +29,7 @@ diagnostic_msgs/DiagnosticArray
 The diagnostics information.
 
 ### Parameters
-#### ntp_hostname 
+#### ntp_hostname
 (default: "pool.ntp.org")
 Hostname of NTP server.
 
@@ -44,9 +53,6 @@ Computer name in diagnostics output (ex: 'c1')
 Disable self test.
 
 ## hd_monitor.py
-**To be ported**
-
-## cpu_monitor.py
 **To be ported**
 
 ## ram_monitor.py

--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, TNO IVS, Helmond, Netherlands
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the TNO IVS nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# \author Rein Appeldoorn
+
+import collections
+import rclpy
+import socket
+import psutil
+
+from rclpy.node import Node
+from diagnostic_msgs.msg import DiagnosticStatus
+from diagnostic_updater import DiagnosticTask, Updater
+
+
+class CpuTask(DiagnosticTask):
+    def __init__(self, node, hostname, warning_percentage=90, window=1):
+        DiagnosticTask.__init__(self, "CPU Information")
+
+        self._nh: Node = node
+        self._warning_percentage = int(warning_percentage)
+        self._readings = collections.deque(maxlen=window)
+
+        # Create diagnostic updater with default updater rate of 1 hz
+        self.updater = Updater(self._nh, period=1.0)
+        self.updater.setHardwareID(hostname)
+
+        # Add task to diagnostic updater with the callback producing the diagnostic messages
+        self.updater.add(hostname, self.produce_diagnostics)
+
+    def _get_average_reading(self):
+        def avg(lst):
+            return float(sum(lst)) / len(lst) if lst else float('nan')
+
+        return [avg(cpu_percentages) for cpu_percentages in zip(*self._readings)]
+
+    def produce_diagnostics(self, stat):
+        self._readings.append(psutil.cpu_percent(percpu=True))
+        cpu_percentages = self._get_average_reading()
+        cpu_average = sum(cpu_percentages) / len(cpu_percentages)
+
+        stat.add("CPU Load Average", "{:.2f}".format(cpu_average))
+
+        warn = False
+        for idx, val in enumerate(cpu_percentages):
+            stat.add("CPU {} Load".format(idx), "{:.2f}".format(val))
+            if val > self._warning_percentage:
+                warn = True
+
+        if warn:
+            stat.summary(DiagnosticStatus.WARN,
+                         "At least one CPU exceeds {:d} percent".format(self._warning_percentage))
+        else:
+            stat.summary(DiagnosticStatus.OK, "CPU Average {:.2f} percent".format(cpu_average))
+
+        return stat
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    # Create the node
+    hostname = socket.gethostname()
+    node = Node('cpu_monitor_%s' % hostname.replace("-", "_"))
+
+    # Declare and get parameters
+    node.declare_parameter('warning_percentage', 90)
+    node.declare_parameter('window', 1)
+
+    warning_percentage = node.get_parameter('warning_percentage').get_parameter_value().integer_value
+    window = node.get_parameter('window').get_parameter_value().integer_value
+
+    # Create the CpuTask
+    CpuTask(node=node, hostname=hostname, warning_percentage=warning_percentage, window=window)
+
+    rclpy.spin(node)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass
+    except Exception:
+        import traceback
+        traceback.print_exc()

--- a/diagnostic_common_diagnostics/mainpage.dox
+++ b/diagnostic_common_diagnostics/mainpage.dox
@@ -5,6 +5,7 @@
 \b diagnostic_common_diagnostics contains a few common diagnostic nodes
 
 - ntp_monitor publishes diagnostic messages for how well the NTP time sync is working.
+- cpu_monitor publishes diagnostic messages with the CPU usage of the system.
 - tf_monitor used to publish diagnostic messages reporting on the health of
 the TF tree. It is based on tfwtf. It is not ported to ROS2.
 

--- a/diagnostic_common_diagnostics/test/systemtest/test_cpu_monitor.py
+++ b/diagnostic_common_diagnostics/test/systemtest/test_cpu_monitor.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2023, Robert Bosch GmbH
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+import time
+from diagnostic_msgs.msg import DiagnosticStatus
+from diagnostic_updater import DiagnosticStatusWrapper
+from diagnostic_common_diagnostics.cpu_monitor import CpuTask
+
+class TestCPUMonitor(unittest.TestCase):
+    def test_ok(self):
+        warning_percentage = 100
+        task = CpuTask(warning_percentage)
+        stat = DiagnosticStatusWrapper()
+        task.run(stat)
+        self.assertEqual(task.name, 'CPU Information')
+        self.assertEqual(stat.level, DiagnosticStatus.OK)
+        self.assertIn(str('CPU Average'), stat.message)
+
+        # Check for at least 1 CPU Load Average and 1 CPU Load
+        self.assertGreaterEqual(len(stat.values), 2)
+
+    def test_warn(self):
+        # time.sleep(0.1)
+
+        warning_percentage2 = 0
+        task2 = CpuTask(warning_percentage2)
+        stat2 = DiagnosticStatusWrapper()
+        task2.run(stat2)
+        self.assertEqual(task2.name, 'CPU Information')
+        self.assertEqual(stat2.level, DiagnosticStatus.WARN)
+        self.assertIn(str('At least one CPU exceeds'), stat2.message)
+
+        # Check for at least 1 CPU Load Average and 1 CPU Load
+        self.assertGreaterEqual(len(stat2.values), 2)
+        # time.sleep(0.25)
+
+    # def test_updater(self):
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I made an attempt to port the cpu_monitor to ROS2. The module allows users to monitor the CPU usage of their system in real time. It publishes the usage percentage in a diagnostic message.

- I kept the ros arguments warning_percentage and window.
- Added 3 unit tests 

Question to you guys; is the test test_updater() overkill in this context or does it add value? 
