### PR TITLE
Add add_analyzer functionality

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -162,6 +162,7 @@ ament_python_install_package(${PROJECT_NAME})
 
 # Install Example
 set(ANALYZER_PARAMS_FILEPATH "${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/example_analyzers.yaml")
+set(ADD_ANALYZER_PARAMS_FILEPATH "${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/example_add_analyzers.yaml")
 configure_file(example/example.launch.py.in example.launch.py @ONLY)
 install( # launch descriptor
   FILES ${CMAKE_CURRENT_BINARY_DIR}/example.launch.py
@@ -172,7 +173,7 @@ install( # example publisher
   DESTINATION lib/${PROJECT_NAME}
 )
 install( # example aggregator configration
-  FILES example/example_analyzers.yaml
+  FILES example/example_analyzers.yaml example/example_add_analyzers.yaml
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -82,6 +82,7 @@ if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake REQUIRED)
 
   file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}/aggregator_node" AGGREGATOR_NODE)
+  file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}/add_analyzer" ADD_ANALYZER)
   file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/test_listener.py" TEST_LISTENER)
   set(create_analyzers_tests
     "primitive_analyzers"
@@ -124,6 +125,27 @@ if(BUILD_TESTING)
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_output_${test_name}.launch.py"
       TARGET "test_output_${test_name}"
+      TIMEOUT 30
+      ENV
+    )
+  endforeach()
+
+  set(add_analyzers_tests
+  "all_analyzers")
+
+  foreach(test_name ${add_analyzers_tests})
+    file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/default.yaml" PARAMETER_FILE)
+    file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/${test_name}.yaml" ADD_PARAMETER_FILE)
+    file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/expected_output/add_${test_name}" EXPECTED_OUTPUT)
+
+    configure_file(
+      "test/add_analyzers.launch.py.in"
+      "test_add_${test_name}.launch.py"
+      @ONLY
+    )
+    add_launch_test(
+      "${CMAKE_CURRENT_BINARY_DIR}/test_add_${test_name}.launch.py"
+      TARGET "test_add_${test_name}"
       TIMEOUT 30
       ENV
     )

--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(ament_cmake REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(std_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
@@ -66,6 +67,10 @@ target_compile_definitions(${ANALYZERS} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIO
 add_executable(aggregator_node src/aggregator_node.cpp)
 target_link_libraries(aggregator_node
   ${PROJECT_NAME})
+
+# Add analyzer
+add_executable(add_analyzer src/add_analyzer.cpp)
+ament_target_dependencies(add_analyzer rclcpp rcl_interfaces)
 
 # Testing macro
 if(BUILD_TESTING)
@@ -132,6 +137,11 @@ endif()
 
 install(
   TARGETS aggregator_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  TARGETS add_analyzer
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/diagnostic_aggregator/README.md
+++ b/diagnostic_aggregator/README.md
@@ -132,6 +132,33 @@ You can launch the `aggregator_node` like this (see [example.launch.py.in](examp
     ])
 ```
 
+You can add analyzers at runtime using the `add_analyzer` node like this (see [example.launch.py.in](example/example.launch.py.in)):
+```
+    add_analyzer = launch_ros.actions.Node(
+        package='diagnostic_aggregator',
+        executable='add_analyzer',
+        output='screen',
+        parameters=[add_analyzer_params_filepath])
+    return launch.LaunchDescription([
+        add_analyzer,
+    ])
+```
+This node updates the parameters of the `aggregator_node` by calling the service `/analyzers/set_parameters_atomically`.
+The `aggregator_node` will detect when a `parameter-event` has introduced new parameters to it.
+When this happens the `aggregator_node` will reload all analyzers based on its new set of parameters.
+Adding analyzers this way can be done at runtime and can be made conditional.
+
+In the example, `add_analyzer` will add an analyzer for diagnostics that are marked optional:
+``` yaml
+/**:
+  ros__parameters:
+    optional:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: Optional
+      startswith: [ '/optional' ]
+```
+This will move the `/optional/runtime/analyzer` diagnostic from the "Other" to  "Aggregation" where it will not go stale after 5 seconds and will be taken into account for the toplevel state.
+
 # Basic analyzers
 The `diagnostic_aggregator` package provides a few basic analyzers that you can use to aggregate your diagnostics.
 

--- a/diagnostic_aggregator/example/README.md
+++ b/diagnostic_aggregator/example/README.md
@@ -1,5 +1,7 @@
 # Aggregator Example
 
-This is a simple example to show the diagnostic_aggregator in action. It involves one python script producing dummy diagnostic data ([example_pub.py](./example_pub.py)), and one diagnostic aggregator configuration ([example.yaml](./example.yaml)) that provides analyzers aggregating it.
+This is a simple example to show the diagnostic_aggregator and add_analyzer in action. It involves one python script producing dummy diagnostic data ([example_pub.py](./example_pub.py)), one diagnostic aggregator configuration ([example_analyzers.yaml](./example_analyzers.yaml)) and one add_analyzer configuration ([example_add_analyzers.yaml](./example_add_analyzers.yaml)).
+
+The aggregator will launch and load all the analyzers listed in ([example_analyzers.yaml](./example_analyzers.yaml)). Then the aggregator will be notified that there are additional analyzers that we also want to load in ([example_add_analyzers.yaml](./example_add_analyzers.yaml)). After this reload all analyzers will be active.
 
 Run the example with `ros2 launch diagnostic_aggregator example.launch.py`

--- a/diagnostic_aggregator/example/example.launch.py.in
+++ b/diagnostic_aggregator/example/example.launch.py.in
@@ -4,6 +4,7 @@ import launch
 import launch_ros.actions
 
 analyzer_params_filepath = "@ANALYZER_PARAMS_FILEPATH@"
+add_analyzer_params_filepath = "@ADD_ANALYZER_PARAMS_FILEPATH@"
 
 
 def generate_launch_description():
@@ -12,11 +13,18 @@ def generate_launch_description():
         executable='aggregator_node',
         output='screen',
         parameters=[analyzer_params_filepath])
+    add_analyzer = launch_ros.actions.Node(
+        package='diagnostic_aggregator',
+        executable='add_analyzer',
+        output='screen',
+        parameters=[add_analyzer_params_filepath]
+    )
     diag_publisher = launch_ros.actions.Node(
         package='diagnostic_aggregator',
         executable='example_pub.py')
     return launch.LaunchDescription([
         aggregator,
+        add_analyzer,
         diag_publisher,
         launch.actions.RegisterEventHandler(
             event_handler=launch.event_handlers.OnProcessExit(

--- a/diagnostic_aggregator/example/example_add_analyzers.yaml
+++ b/diagnostic_aggregator/example/example_add_analyzers.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    optional:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: Optional
+      contains: [ '/optional' ]

--- a/diagnostic_aggregator/example/example_pub.py
+++ b/diagnostic_aggregator/example/example_pub.py
@@ -81,6 +81,10 @@ class DiagnosticTalker(Node):
                              name='/sensors/front/cam', message='OK'),
             DiagnosticStatus(level=DiagnosticStatus.OK,
                              name='/sensors/rear/cam', message='OK'),
+
+            # Optional
+            DiagnosticStatus(level=DiagnosticStatus.OK,
+                            name='/optional/runtime/analyzer', message='OK'),
         ]
 
     def timer_callback(self):

--- a/diagnostic_aggregator/example/example_pub.py
+++ b/diagnostic_aggregator/example/example_pub.py
@@ -84,7 +84,7 @@ class DiagnosticTalker(Node):
 
             # Optional
             DiagnosticStatus(level=DiagnosticStatus.OK,
-                            name='/optional/runtime/analyzer', message='OK'),
+                             name='/optional/runtime/analyzer', message='OK'),
         ]
 
     def timer_callback(self):

--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -133,6 +133,8 @@ private:
   rclcpp::Service<diagnostic_msgs::srv::AddDiagnostics>::SharedPtr add_srv_;
   /// DiagnosticArray, /diagnostics
   rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diag_sub_;
+  /// ParameterEvent, /parameter_events
+  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr param_sub_;
   /// DiagnosticArray, /diagnostics_agg
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr agg_pub_;
   /// DiagnosticStatus, /diagnostics_toplevel_state
@@ -164,6 +166,16 @@ private:
 
   /// Records all ROS warnings. No warnings are repeated.
   std::set<std::string> ros_warnings_;
+
+  /*
+   *!\brief Checks for new parameters to trigger reinitialization of the AnalyzerGroup and OtherAnalyzer
+   */
+  void parameterCallback(const rcl_interfaces::msg::ParameterEvent::SharedPtr param_msg);
+
+  /*
+   *!\brief (re)initializes the AnalyzerGroup and OtherAnalyzer
+   */
+  void initAnalyzers();
 
   /*
    *!\brief Checks timestamp of message, and warns if timestamp is 0 (not set)

--- a/diagnostic_aggregator/package.xml
+++ b/diagnostic_aggregator/package.xml
@@ -12,7 +12,7 @@
   <license>BSD-3-Clause</license>
 
   <url type="website">http://www.ros.org/wiki/diagnostic_aggregator</url>
-  
+
   <author>Kevin Watts</author>
   <author email="brice.rebsamen@gmail.com">Brice Rebsamen</author>
   <author email="arne.nordmann@de.bosch.com">Arne Nordmann</author>
@@ -22,6 +22,7 @@
 
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>rcl_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
 

--- a/diagnostic_aggregator/src/add_analyzer.cpp
+++ b/diagnostic_aggregator/src/add_analyzer.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2009, Willow Garage, Inc.
+ *  Copyright (c) 2024, Nobleo Technology
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
+ *   * Neither the name of the copyright holder nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/diagnostic_aggregator/src/add_analyzer.cpp
+++ b/diagnostic_aggregator/src/add_analyzer.cpp
@@ -77,7 +77,6 @@ public:
         // Check in map if the stripped param name with the added suffix "path" exists
         // This indicates the parameter is part of an analyzer description
         if (parameters.count(stripped_param_name + ".path") > 0) {
-          RCLCPP_INFO(this->get_logger(), param_name.c_str());
           auto parameter_msg = param.to_parameter_msg();
           request->parameters.push_back(parameter_msg);
         }

--- a/diagnostic_aggregator/src/add_analyzer.cpp
+++ b/diagnostic_aggregator/src/add_analyzer.cpp
@@ -66,7 +66,7 @@ public:
     std::map<std::string, rclcpp::Parameter> parameters;
     if (this->get_parameters("", parameters)) {
       for (const auto & param : parameters) {
-        if (param.first.substr(0, prefix_.length()).compare(prefix_) == 0) {
+        if (param.first.substr(0, analyzers_ns_.length()).compare(analyzers_ns_) == 0) {
           auto parameter_msg = param.second.to_parameter_msg();
           request->parameters.push_back(parameter_msg);
         }
@@ -85,7 +85,7 @@ public:
 
 private:
   rclcpp::Client<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr client_;
-  std::string prefix_ = "analyzers.";
+  std::string analyzers_ns_ = "analyzers.";
 };
 
 int main(int argc, char ** argv)

--- a/diagnostic_aggregator/src/add_analyzer.cpp
+++ b/diagnostic_aggregator/src/add_analyzer.cpp
@@ -1,10 +1,44 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2009, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/**< \author Martin Cornelis */
+
+#include <chrono>
+
 #include "rclcpp/rclcpp.hpp"
 #include "rcl_interfaces/srv/set_parameters_atomically.hpp"
 #include "rcl_interfaces/msg/parameter.hpp"
-
-#include <chrono>
-#include <cstdlib>
-#include <memory>
 
 using namespace std::chrono_literals;
 

--- a/diagnostic_aggregator/src/add_analyzer.cpp
+++ b/diagnostic_aggregator/src/add_analyzer.cpp
@@ -1,0 +1,100 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2009, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/**< \author Martin Cornelis */
+
+#include <chrono>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/srv/set_parameters_atomically.hpp"
+#include "rcl_interfaces/msg/parameter.hpp"
+
+using namespace std::chrono_literals;
+
+class AddAnalyzer : public rclcpp::Node
+{
+public:
+  AddAnalyzer()
+  : Node("add_analyzer_node", "", rclcpp::NodeOptions().allow_undeclared_parameters(
+        true).automatically_declare_parameters_from_overrides(true))
+  {
+    client_ = this->create_client<rcl_interfaces::srv::SetParametersAtomically>(
+      "/diagnostics_agg/set_parameters_atomically");
+  }
+
+  void send_request()
+  {
+    while (!client_->wait_for_service(1s)) {
+      if (!rclcpp::ok()) {
+        RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for the service. Exiting.");
+        return;
+      }
+      RCLCPP_INFO_ONCE(this->get_logger(), "service not available, waiting ...");
+    }
+    auto request = std::make_shared<rcl_interfaces::srv::SetParametersAtomically::Request>();
+    std::map<std::string, rclcpp::Parameter> parameters;
+    if (this->get_parameters("", parameters)) {
+      for (const auto & param : parameters) {
+        if (param.first.substr(0, analyzers_ns_.length()).compare(analyzers_ns_) == 0) {
+          auto parameter_msg = param.second.to_parameter_msg();
+          request->parameters.push_back(parameter_msg);
+        }
+      }
+    }
+    auto result = client_->async_send_request(request);
+    // Wait for the result.
+    if (rclcpp::spin_until_future_complete(this->get_node_base_interface(), result) ==
+      rclcpp::FutureReturnCode::SUCCESS)
+    {
+      RCLCPP_INFO(this->get_logger(), "Parameters succesfully set");
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "Failed to set parameters");
+    }
+  }
+
+private:
+  rclcpp::Client<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr client_;
+  std::string analyzers_ns_ = "analyzers.";
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto add_analyzer = std::make_shared<AddAnalyzer>();
+  add_analyzer->send_request();
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/diagnostic_aggregator/src/add_analyzer.cpp
+++ b/diagnostic_aggregator/src/add_analyzer.cpp
@@ -1,0 +1,66 @@
+#include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/srv/set_parameters_atomically.hpp"
+#include "rcl_interfaces/msg/parameter.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+
+using namespace std::chrono_literals;
+
+class AddAnalyzer : public rclcpp::Node
+{
+public:
+  AddAnalyzer()
+  : Node("add_analyzer_node", "", rclcpp::NodeOptions().allow_undeclared_parameters(
+        true).automatically_declare_parameters_from_overrides(true))
+  {
+    client_ = this->create_client<rcl_interfaces::srv::SetParametersAtomically>(
+      "/diagnostics_agg/set_parameters_atomically");
+  }
+
+  void send_request()
+  {
+    while (!client_->wait_for_service(1s)) {
+      if (!rclcpp::ok()) {
+        RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for the service. Exiting.");
+        return;
+      }
+      RCLCPP_INFO_ONCE(this->get_logger(), "service not available, waiting ...");
+    }
+    auto request = std::make_shared<rcl_interfaces::srv::SetParametersAtomically::Request>();
+    std::map<std::string, rclcpp::Parameter> parameters;
+    if (this->get_parameters("", parameters)) {
+      for (const auto & param : parameters) {
+        if (param.first.substr(0, prefix_.length()).compare(prefix_) == 0) {
+          auto parameter_msg = param.second.to_parameter_msg();
+          request->parameters.push_back(parameter_msg);
+        }
+      }
+    }
+    auto result = client_->async_send_request(request);
+    // Wait for the result.
+    if (rclcpp::spin_until_future_complete(this->get_node_base_interface(), result) ==
+      rclcpp::FutureReturnCode::SUCCESS)
+    {
+      RCLCPP_INFO(this->get_logger(), "Parameters succesfully set");
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "Failed to set parameters");
+    }
+  }
+
+private:
+  rclcpp::Client<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr client_;
+  std::string prefix_ = "analyzers.";
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto add_analyzer = std::make_shared<AddAnalyzer>();
+  add_analyzer->send_request();
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/diagnostic_aggregator/src/add_analyzer.cpp
+++ b/diagnostic_aggregator/src/add_analyzer.cpp
@@ -96,7 +96,6 @@ public:
 
 private:
   rclcpp::Client<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr client_;
-  std::string analyzers_ns_ = "analyzers.";
 };
 
 int main(int argc, char ** argv)

--- a/diagnostic_aggregator/src/add_analyzer.cpp
+++ b/diagnostic_aggregator/src/add_analyzer.cpp
@@ -72,11 +72,11 @@ public:
       // Find the suffix
       size_t suffix_start = param_name.find_last_of('.');
       // Remove suffix if it exists
-      if (suffix_start != std::string::npos){
+      if (suffix_start != std::string::npos) {
         std::string stripped_param_name = param_name.substr(0, suffix_start);
         // Check in map if the stripped param name with the added suffix "path" exists
         // This indicates the parameter is part of an analyzer description
-        if (parameters.count(stripped_param_name+".path") > 0) {
+        if (parameters.count(stripped_param_name + ".path") > 0) {
           RCLCPP_INFO(this->get_logger(), param_name.c_str());
           auto parameter_msg = param.to_parameter_msg();
           request->parameters.push_back(parameter_msg);

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -92,7 +92,7 @@ void Aggregator::parameterCallback(const rcl_interfaces::msg::ParameterEvent::Sh
 {
   if (msg->node == "/" + std::string(n_->get_name())) {
     if (msg->new_parameters.size() != 0) {
-      base_path_="";
+      base_path_ = "";
       initAnalyzers();
     }
   }

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -59,7 +59,8 @@ using diagnostic_msgs::msg::DiagnosticStatus;
 Aggregator::Aggregator()
 : n_(std::make_shared<rclcpp::Node>(
       "analyzers", "",
-      rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true))),
+      rclcpp::NodeOptions().allow_undeclared_parameters(true).
+      automatically_declare_parameters_from_overrides(true))),
   logger_(rclcpp::get_logger("Aggregator")),
   pub_rate_(1.0),
   history_depth_(1000),
@@ -69,6 +70,35 @@ Aggregator::Aggregator()
   last_top_level_state_(DiagnosticStatus::STALE)
 {
   RCLCPP_DEBUG(logger_, "constructor");
+  initAnalyzers();
+
+  diag_sub_ = n_->create_subscription<DiagnosticArray>(
+    "/diagnostics", rclcpp::SystemDefaultsQoS().keep_last(history_depth_),
+    std::bind(&Aggregator::diagCallback, this, _1));
+  agg_pub_ = n_->create_publisher<DiagnosticArray>("/diagnostics_agg", 1);
+  toplevel_state_pub_ =
+    n_->create_publisher<DiagnosticStatus>("/diagnostics_toplevel_state", 1);
+
+  int publish_rate_ms = 1000 / pub_rate_;
+  publish_timer_ = n_->create_wall_timer(
+    std::chrono::milliseconds(publish_rate_ms),
+    std::bind(&Aggregator::publishData, this));
+
+  param_sub_ = n_->create_subscription<rcl_interfaces::msg::ParameterEvent>(
+    "/parameter_events", 1, std::bind(&Aggregator::parameterCallback, this, _1));
+}
+
+void Aggregator::parameterCallback(const rcl_interfaces::msg::ParameterEvent::SharedPtr msg)
+{
+  if (msg->node == "/" + std::string(n_->get_name())) {
+    if (msg->new_parameters.size() != 0) {
+      initAnalyzers();
+    }
+  }
+}
+
+void Aggregator::initAnalyzers()
+{
   bool other_as_errors = false;
 
   std::map<std::string, rclcpp::Parameter> parameters;
@@ -101,26 +131,17 @@ Aggregator::Aggregator()
   RCLCPP_DEBUG(
     logger_, "Aggregator critical publisher configured to: %s", (critical_ ? "true" : "false"));
 
-  analyzer_group_ = std::make_unique<AnalyzerGroup>();
-  if (!analyzer_group_->init(base_path_, "", n_)) {
-    RCLCPP_ERROR(logger_, "Analyzer group for diagnostic aggregator failed to initialize!");
+  {  // lock the mutex while analyzer_group_ and other_analyzer_ are being updated
+    std::lock_guard<std::mutex> lock(mutex_);
+    analyzer_group_ = std::make_unique<AnalyzerGroup>();
+    if (!analyzer_group_->init(base_path_, "", n_)) {
+      RCLCPP_ERROR(logger_, "Analyzer group for diagnostic aggregator failed to initialize!");
+    }
+
+    // Last analyzer handles remaining data
+    other_analyzer_ = std::make_unique<OtherAnalyzer>(other_as_errors);
+    other_analyzer_->init(base_path_);  // This always returns true
   }
-
-  // Last analyzer handles remaining data
-  other_analyzer_ = std::make_unique<OtherAnalyzer>(other_as_errors);
-  other_analyzer_->init(base_path_);  // This always returns true
-
-  diag_sub_ = n_->create_subscription<DiagnosticArray>(
-    "/diagnostics", rclcpp::SystemDefaultsQoS().keep_last(history_depth_),
-    std::bind(&Aggregator::diagCallback, this, _1));
-  agg_pub_ = n_->create_publisher<DiagnosticArray>("/diagnostics_agg", 1);
-  toplevel_state_pub_ =
-    n_->create_publisher<DiagnosticStatus>("/diagnostics_toplevel_state", 1);
-
-  int publish_rate_ms = 1000 / pub_rate_;
-  publish_timer_ = n_->create_wall_timer(
-    std::chrono::milliseconds(publish_rate_ms),
-    std::bind(&Aggregator::publishData, this));
 }
 
 void Aggregator::checkTimestamp(const DiagnosticArray::SharedPtr diag_msg)

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -92,6 +92,7 @@ void Aggregator::parameterCallback(const rcl_interfaces::msg::ParameterEvent::Sh
 {
   if (msg->node == "/" + std::string(n_->get_name())) {
     if (msg->new_parameters.size() != 0) {
+      base_path_="";
       initAnalyzers();
     }
   }

--- a/diagnostic_aggregator/test/add_analyzers.launch.py.in
+++ b/diagnostic_aggregator/test/add_analyzers.launch.py.in
@@ -1,0 +1,74 @@
+import os
+
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.events import matches_action
+from launch.events.process import ShutdownProcess
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.util
+import launch_testing_ros
+
+
+def generate_test_description():
+    os.environ['OSPL_VERBOSITY'] = '8'
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
+
+    aggregator_node = ExecuteProcess(
+        cmd=[
+            "@AGGREGATOR_NODE@",
+            "--ros-args",
+            "--params-file",
+            "@PARAMETER_FILE@"
+            ],
+        name='aggregator_node',
+        emulate_tty=True,
+        output='screen')
+
+    add_analyzer = ExecuteProcess(
+        cmd=[
+            "@ADD_ANALYZER@",
+            "--ros-args",
+            "--params-file",
+            "@ADD_PARAMETER_FILE@"
+            ],
+        name='add_analyzer',
+        emulate_tty=True,
+        output='screen')
+
+    launch_description = LaunchDescription()
+    launch_description.add_action(aggregator_node)
+    launch_description.add_action(add_analyzer)
+    launch_description.add_action(launch_testing.util.KeepAliveProc())
+    launch_description.add_action(launch_testing.actions.ReadyToTest())
+    return launch_description, locals()
+
+class TestAggregator(unittest.TestCase):
+
+    def test_processes_output(self, proc_output, aggregator_node):
+        """Check aggregator logging output for expected strings."""
+
+        from launch_testing.tools.output import get_default_filtered_prefixes
+        output_filter = launch_testing_ros.tools.basic_output_filter(
+            filtered_prefixes=get_default_filtered_prefixes() + ['service not available, waiting...'],
+            filtered_rmw_implementation='@rmw_implementation@'
+        )
+        proc_output.assertWaitFor(
+            expected_output=launch_testing.tools.expected_output_from_file(path="@EXPECTED_OUTPUT@"),
+            process=aggregator_node,
+            output_filter=output_filter,
+            timeout=15
+        )
+
+        import time
+        time.sleep(1)
+
+@launch_testing.post_shutdown_test()
+class TestAggregatorShutdown(unittest.TestCase):
+
+    def test_last_process_exit_code(self, proc_info, aggregator_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=aggregator_node)

--- a/diagnostic_aggregator/test/all_analyzers.yaml
+++ b/diagnostic_aggregator/test/all_analyzers.yaml
@@ -1,4 +1,4 @@
-analyzers:
+/**:
   ros__parameters:
     path: BASIC
     prefix1:

--- a/diagnostic_aggregator/test/analyzer_group.yaml
+++ b/diagnostic_aggregator/test/analyzer_group.yaml
@@ -1,4 +1,4 @@
-analyzers:
+/**:
   ros__parameters:
     path: TEST
     primary:

--- a/diagnostic_aggregator/test/default.yaml
+++ b/diagnostic_aggregator/test/default.yaml
@@ -1,0 +1,9 @@
+/**:
+  ros__parameters:
+    path: BASIC
+    prefix0:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: Zeroth
+      contains: [
+        'contain0a',
+        'contain0b' ]

--- a/diagnostic_aggregator/test/empty_root_path.yaml
+++ b/diagnostic_aggregator/test/empty_root_path.yaml
@@ -1,4 +1,4 @@
-analyzers:
+/**:
   ros__parameters:
     primary:
       type: 'diagnostic_aggregator/AnalyzerGroup'

--- a/diagnostic_aggregator/test/expected_output/add_all_analyzers.txt
+++ b/diagnostic_aggregator/test/expected_output/add_all_analyzers.txt
@@ -1,0 +1,6 @@
+/BASIC/Zeroth
+prefix0
+/BASIC/First
+prefix1
+/BASIC/Third
+prefix3

--- a/diagnostic_aggregator/test/expected_stale_analyzers.yaml
+++ b/diagnostic_aggregator/test/expected_stale_analyzers.yaml
@@ -1,4 +1,4 @@
-analyzers:
+/**:
   my_path:
     type: diagnostic_aggregator/GenericAnalyzer
     path: My Path

--- a/diagnostic_aggregator/test/multiple_match_analyzers.yaml
+++ b/diagnostic_aggregator/test/multiple_match_analyzers.yaml
@@ -1,4 +1,4 @@
-analyzers:
+/**:
   my_path:
     type: diagnostic_aggregator/GenericAnalyzer
     path: Header1

--- a/diagnostic_aggregator/test/primitive_analyzers.yaml
+++ b/diagnostic_aggregator/test/primitive_analyzers.yaml
@@ -1,4 +1,4 @@
-analyzers:
+/**:
   ros__parameters:
     log_level: debug
     primary:


### PR DESCRIPTION
Applied the following changes to allow adding analyzers at runtime similar to the ROS1 functionality. 

- Move the creation of `analyzer_group_ ` and `other_analyzer_` from the constructor to a new function `initAnalyzers()`.
- Added a subscriber to parameter events `param_sub_` that triggers a callback `parameterCallback`.
- Check in the callback if `this` node got any new paramters -> if true, lock the mutex and call `initAnalyzers()` again.

- Created an `add_analyzer` node that forwards its own parameters to the `diagnostic_aggregator` by sending a request to `/diagnostics_agg/set_parameters_atomically` service

- **(EDIT) [The `add_analyzer` looks for all parameters starting with the prefix `analyzers.`,] has been replaced with [The `add_analyzer` looks for all parameters for which a similar named parameter exists with the suffix ".path"]** converts them to a parameter_msg and sends them together as one `SetParametersAtomically::Request`

Example usage:
```
<node name="add_my_analyzer" pkg="diagnostic_aggregator" exec="add_analyzer" >
        <param from="$(find-pkg-share <pkg_name>)/param/<param_file_path>.yaml" allow_substs="true"/>
        <remap from="/diagnostics_agg/set_parameters_atomically" to="/diagnostics_autonomy/set_parameters_atomically" />
</node>
```