### PR TITLE
Fix release target documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ The [`ros2` branch](https://github.com/ros/diagnostics/tree/ros2) targets
 
 - *Humble Hawksbill*
 - *Iron Irwini* and
-- *Rolling Ridley*
 
 The [`ros2-jazzy` branch](https://github.com/ros/diagnostics/tree/ros2-jazzy) targets
 
 - *Jazzy Jalisco*
+- *Rolling Ridley*
 
 # License
 


### PR DESCRIPTION
Is see that there are now two branches `ros2` and `ros2-jazzy`. The second branch should target `jazzy` and newer distros, including `rolling`.

To make this more clear you could also change the branch names:
`ros2` -> `ros2-iron` (iron and older)
`ros-jazzy` `ros2` (jazzy and newer)

Or make 1 branch per release
`ros2-humble`
`ros2-iron`
`ros2`