### PR TITLE
NTP monitor improvements

### DIFF
--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/ntp_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/ntp_monitor.py
@@ -51,7 +51,6 @@ class NTPMonitor(Node):
                  diag_hostname=None, error_offset=5000000,
                  do_self_test=True):
         """Initialize the NTPMonitor."""
-
         super().__init__(__class__.__name__)
         self.declare_parameter('frequency', 10.0)
         frequency = self.get_parameter('frequency').get_parameter_value().double_value

--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/ntp_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/ntp_monitor.py
@@ -50,6 +50,7 @@ class NTPMonitor(Node):
                  diag_hostname=None, error_offset=5000000,
                  do_self_test=True):
         """Initialize the NTPMonitor."""
+
         super().__init__(__class__.__name__)
         self.declare_parameter('frequency', 10.0)
         frequency = self.get_parameter('frequency').get_parameter_value().double_value


### PR DESCRIPTION
1. Adds timestamp to diagnostics message
3. parameterize timer frequency
4. fix filtering of ros-args to ignore all args (e.g. --params-file as well) 