### PR TITLE
[ros2-iron] Using ubuntu ntp server in systemtest (#346)

### DIFF
--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/ntp_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/ntp_monitor.py
@@ -37,9 +37,7 @@ import sys
 import threading
 
 import diagnostic_updater as DIAG
-
 import ntplib
-
 import rclpy
 from rclpy.node import Node
 
@@ -145,16 +143,16 @@ class NTPMonitor(Node):
             if (abs(measured_offset) > self.offset):
                 st.level = DIAG.DiagnosticStatus.WARN
                 st.message = \
-                    f'NTP offset above threshold: {measured_offset}>'\
+                    f'NTP offset above threshold: abs({measured_offset})>'\
                     f'{self.offset} us'
             if (abs(measured_offset) > self.error_offset):
                 st.level = DIAG.DiagnosticStatus.ERROR
                 st.message = \
-                    f'NTP offset above error threshold: {measured_offset}>'\
+                    f'NTP offset above error threshold: abs({measured_offset})>'\
                     f'{self.error_offset} us'
             if (abs(measured_offset) < self.offset):
                 st.level = DIAG.DiagnosticStatus.OK
-                st.message = f'NTP Offset OK: {measured_offset} us'
+                st.message = f'NTP Offset OK: abs({measured_offset}) us'
 
         return st
 

--- a/diagnostic_common_diagnostics/test/systemtest/test_ntp_monitor_launchtest.py
+++ b/diagnostic_common_diagnostics/test/systemtest/test_ntp_monitor_launchtest.py
@@ -35,17 +35,11 @@
 import unittest
 
 from diagnostic_msgs.msg import DiagnosticArray
-
 import launch
-
 import launch_ros
-
 import launch_testing
-
 from launch_testing_ros import WaitForTopics
-
 import pytest
-
 import rclpy
 
 
@@ -58,9 +52,10 @@ def generate_test_description():
             executable='ntp_monitor.py',
             name='ntp_monitor',
             output='screen',
-            arguments=['--offset-tolerance', '10000',
-                       '--error-offset-tolerance', '20000']
-            # 10s, 20s, we are not testing if your clock is correct
+            arguments=['--offset-tolerance', '100000',
+                       '--error-offset-tolerance', '200000',
+                       '--ntp_hostname', 'ntp.ubuntu.com']
+            # 100s, 200s, we are not testing if your clock is correct
         ),
         launch_testing.actions.ReadyToTest()
     ])


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-iron`:
 - [Using ubuntu ntp server in systemtest (#346)](https://github.com/ros/diagnostics/pull/346)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)