### PR TITLE
Fix usage of rclcpp::ok with a non-default context

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -511,7 +511,7 @@ private:
    */
   void update()
   {
-    if (rclcpp::ok()) {
+    if (rclcpp::ok(base_interface_->get_context())) {
       bool warn_nohwid = hwid_.empty();
 
       std::vector<diagnostic_msgs::msg::DiagnosticStatus> status_vec;

--- a/diagnostic_updater/test/diagnostic_updater_test.cpp
+++ b/diagnostic_updater/test/diagnostic_updater_test.cpp
@@ -134,6 +134,42 @@ TEST(DiagnosticUpdater, testUpdaterAsNodeClassMember) {
   SUCCEED();
 }
 
+class SaveIfCalled : public diagnostic_updater::DiagnosticTask
+{
+public:
+  SaveIfCalled()
+  : DiagnosticTask("SaveIfCalled") {}
+
+  void run(diagnostic_updater::DiagnosticStatusWrapper & s)
+  {
+    s.summary(0, "Have been called!");
+    has_been_called_ = true;
+  }
+
+  bool has_been_called() const
+  {
+    return has_been_called_;
+  }
+
+private:
+  bool has_been_called_ = false;
+};
+
+
+TEST(DiagnosticUpdater, testCustomContext) {
+  auto context = std::make_shared<rclcpp::Context>();
+  context->init(0, nullptr, rclcpp::InitOptions());
+
+  auto node =
+    std::make_shared<rclcpp::Node>("CustomContextNode", rclcpp::NodeOptions().context(context));
+  diagnostic_updater::Updater updater(node);
+  SaveIfCalled save_if_called;
+  updater.add(save_if_called);
+  updater.force_update();
+  ASSERT_TRUE(save_if_called.has_been_called());
+  context->shutdown("End test");
+}
+
 TEST(DiagnosticUpdater, testDiagnosticStatusWrapperKeyValuePairs) {
   diagnostic_updater::DiagnosticStatusWrapper stat;
 


### PR DESCRIPTION
The current implementation calls `rclcpp::ok` without any arguments, which amounts to verifying that the global default context is valid. In the case where a node is added to a custom context, and the global context is not used, `rclcpp::ok` without any arguments will always return `false` since the global context has never been initialized. To fix it, pass to rclcpp the context that's available via the node's base interface.

I also added a simple test that fails without 548f960d0913a38ec4d5d2d7756d0661126e1030 but passes with it.