### PR TITLE
[ros2-humble] change(diagnosed-publisher): allow specifying node clock (#340)

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -226,8 +226,9 @@ public:
     const typename PublisherT::SharedPtr & pub,
     diagnostic_updater::Updater & diag,
     const diagnostic_updater::FrequencyStatusParam & freq,
-    const diagnostic_updater::TimeStampStatusParam & stamp)
-  : TopicDiagnostic(pub->get_topic_name(), diag, freq, stamp),
+    const diagnostic_updater::TimeStampStatusParam & stamp,
+    const rclcpp::Clock::SharedPtr & clock = std::make_shared<rclcpp::Clock>())
+  : TopicDiagnostic(pub->get_topic_name(), diag, freq, stamp, clock),
     publisher_(pub)
   {
     static_assert(has_header<MessageT>::value, "Message type has to have a header.");


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-humble`:
 - [change(diagnosed-publisher): allow specifying node clock (#340)](https://github.com/ros/diagnostics/pull/340)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)