### PR TITLE
[ros2] Fix correctly exporting the library (#388)

### DIFF
--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -118,6 +118,7 @@ install(
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 
 ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(ament_cmake_python)
 ament_export_dependencies(diagnostic_msgs)


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2-jazzy` to `ros2`:
 - [Fix correctly exporting the library (#388)](https://github.com/ros/diagnostics/pull/388)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)