### PR TITLE
diagnostic_updater: Added documentation of the Python interface.

### DIFF
--- a/diagnostic_updater/.gitignore
+++ b/diagnostic_updater/.gitignore
@@ -1,0 +1,2 @@
+doc/html
+doc/manifest.yaml

--- a/diagnostic_updater/doc/conf.py
+++ b/diagnostic_updater/doc/conf.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+import os, sys, time
+from os.path import abspath, dirname, join
+
+from docutils import nodes
+from sphinx.ext import intersphinx
+
+import catkin_pkg.package
+
+catkin_dir = dirname(dirname(abspath(__file__)))
+catkin_package = catkin_pkg.package.parse_package(join(catkin_dir, catkin_pkg.package.PACKAGE_MANIFEST_FILENAME))
+
+project = catkin_package.name
+copyright = time.strftime("%Y") + ', Czech Technical University in Prague'
+author = ", ".join([a.name for a in catkin_package.authors])
+version = catkin_package.version
+release = catkin_package.version
+
+import catkin_sphinx
+html_theme_path = [catkin_sphinx.get_theme_path()]
+
+# Use ROS theme
+html_theme = 'ros-theme'
+
+# Add any Sphinx extension module names here, as strings. They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.extlinks',
+              'sphinx.ext.viewcode']
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# The suffix of source filenames.
+source_suffix = '.rst'
+
+# The master toctree document.
+master_doc = 'index'
+
+# Resolve ROS message and service dependencies
+ros_distro = os.getenv('ROS_DISTRO', 'latest')
+ros_api_base = 'https://docs.ros.org/en/%s/api/'
+ros_api = ros_api_base % ros_distro
+
+# Example configuration for intersphinx: refer to the Python standard library.
+python_version = '{}.{}'.format(sys.version_info.major, sys.version_info.minor)
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/{}/'.format(python_version), None),
+    'genpy': (ros_api + 'genpy/html', None),
+}
+
+extlinks = {
+    'diagnostic_msgs': (ros_api + 'diagnostic_msgs/html/msg/%s.html', 'diagnostic_msgs/'),
+}
+
+# Produce both class and constructor doc comments
+autoclass_content = 'both'
+
+
+def ros_msg_reference(app, env, node, contnode):
+    text_node = next(iter(contnode.traverse(lambda n: n.tagname == '#text')))
+    parts = text_node.astext().split('.')
+    # diagnostic_msgs.msg.DiagnosticStatus
+    if len(parts) == 3:
+        pkg, obj_type, obj = parts
+    # diagnostic_msgs.msg._DiagnosticStatus.DiagnosticStatus
+    elif len(parts) == 4:
+        pkg, obj_type, module, obj = parts
+        if "_" + obj != module:
+            return intersphinx.missing_reference(app, env, node, contnode)
+    else:
+        return intersphinx.missing_reference(app, env, node, contnode)
+    if obj_type not in ("msg", "srv"):
+        return intersphinx.missing_reference(app, env, node, contnode)
+    target = ros_api + '{}/html/{}/{}.html'.format(pkg, obj_type, obj)
+    ref_node = nodes.reference()
+    ref_node['refuri'] = target
+    title = '{}/{}'.format(pkg, obj)
+    text_node = nodes.literal(title, title)
+    text_node['classes'] = ['xref', 'ros', 'ros-' + obj_type]
+    ref_node += text_node
+    return ref_node
+
+
+# Backport of fix for issue https://github.com/sphinx-doc/sphinx/issues/2549. Without it, :ivar: fields wrongly resolve cross-references.
+from sphinx.domains.python import PyObject
+PyObject.doc_field_types[list(map(lambda f: f.name == 'variable', PyObject.doc_field_types)).index(True)].rolename = None
+
+
+def setup(app):
+    app.connect("missing-reference", ros_msg_reference)
+

--- a/diagnostic_updater/doc/index.rst
+++ b/diagnostic_updater/doc/index.rst
@@ -1,0 +1,21 @@
+Welcome to diagnostic_updater documentation!
+============================================
+
+.. toctree::
+   :maxdepth: 2
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+Module diagnostic\_updater
+==========================
+
+.. automodule:: diagnostic_updater
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/diagnostic_updater/mainpage.dox
+++ b/diagnostic_updater/mainpage.dox
@@ -23,5 +23,7 @@ publication. These libraries are commonly used by device drivers as part of the 
    statistics automatically when publications are made to a topic.
 
 Example uses of these classes can be found in \ref src/example.cpp.
+
+The Python API is described in <a href="python/index.html">python</a> subfolder.
  
  */                                     

--- a/diagnostic_updater/package.xml
+++ b/diagnostic_updater/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>diagnostic_updater</name>
   <version>1.11.0</version>
   <description>diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.</description>
@@ -22,15 +22,19 @@
   <build_depend>rostest</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>std_msgs</run_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  
+  <doc_depend>rosdoc_lite</doc_depend>
+  <doc_depend>python3-catkin-sphinx</doc_depend>
 
   <!-- <test_depend>roscpp</test_depend> -->
   <!-- <test_depend>diagnostic_msgs</test_depend> -->
   <!-- <test_depend>std_msgs</test_depend> -->
 
   <export>
+    <rosdoc config="rosdoc.yaml"/>
     <architecture_independent/>
   </export>
 </package>

--- a/diagnostic_updater/rosdoc.yaml
+++ b/diagnostic_updater/rosdoc.yaml
@@ -1,0 +1,5 @@
+- builder: doxygen
+  name: C++ API
+- builder: sphinx
+  sphinx_root_dir: doc
+  output_dir: python

--- a/diagnostic_updater/src/diagnostic_updater/__init__.py
+++ b/diagnostic_updater/src/diagnostic_updater/__init__.py
@@ -33,7 +33,44 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # -*- coding: utf-8 -*-
+
+"""
+`diagnostic_updater` contains assorted Python classes to assist in diagnostic
+publication. These libraries are commonly used by device drivers as part of the diagnostics
+toolchain. The main parts of `diagnostic_updater` are:
+
+ - :class:`DiagnosticStatusWrapper`, a wrapper providing
+   convenience functions for working with :class:`diagnostics_msgs.msg.DiagnosticStatus`.
+
+ - :class:`Updater`, a class for managing periodic publishing of the
+   :class:`DiagnosticStatusWrapper` output by a set of :class:`DiagnosticTask`.
+
+ - :class:`TopicDiagnostic` and :class:`HeaderlessTopicDiagnostic` for calculating and
+   publishing statistics on timestamps and publication frequencies, and
+   their corresponding :class:`DiagnosedPublisher` and :class:`HeaderlessDiagnosedPublisher`
+   to update the statistics automatically when publications are made to a topic.
+
+Example uses of these classes can be found in `src/example.py`.
+"""
+
 from ._diagnostic_status_wrapper import *
 from ._diagnostic_updater import *
 from ._update_functions import *
 from ._publisher import *
+
+__all__ = [
+  'DiagnosticStatusWrapper',
+  'DiagnosticTask',
+  'FunctionDiagnosticTask',
+  'CompositeDiagnosticTask',
+  'DiagnosticTaskVector',
+  'Updater',
+  'HeaderlessTopicDiagnostic',
+  'TopicDiagnostic',
+  'DiagnosedPublisher',
+  'FrequencyStatusParam',
+  'FrequencyStatus',
+  'TimeStampStatusParam',
+  'TimeStampStatus',
+  'Heartbeat',
+]

--- a/diagnostic_updater/src/diagnostic_updater/_diagnostic_status_wrapper.py
+++ b/diagnostic_updater/src/diagnostic_updater/_diagnostic_status_wrapper.py
@@ -44,12 +44,12 @@ WARN = DiagnosticStatus.WARN
 ERROR = DiagnosticStatus.ERROR
 
 class DiagnosticStatusWrapper(DiagnosticStatus):
-    """ Wrapper for the diagnostic_msgs::DiagnosticStatus message that makes it
+    """ Wrapper for the :diagnostic_msgs:`DiagnosticStatus` message that makes it
     easier to update.
 
     This class handles common string formatting and vector handling issues
-    for filling the diagnostic_msgs::DiagnosticStatus message. It is a subclass of
-    diagnostic_msgs::DiagnosticStatus, so it can be passed directly to
+    for filling the :diagnostic_msgs:`DiagnosticStatus` message. It is a subclass of
+    :diagnostic_msgs:`DiagnosticStatus`, so it can be passed directly to
     diagnostic publish calls.
     """
 
@@ -63,19 +63,21 @@ class DiagnosticStatusWrapper(DiagnosticStatus):
         The available fields are:
         level,name,message,hardware_id,values
 
-        @param args: complete set of field values, in .msg order
-        @param kwds: use keyword arguments corresponding to message field names
-        to set specific fields.
+        :param args: complete set of field values, in .msg order
+        :param kwds: use keyword arguments corresponding to message field names
+                     to set specific fields.
         """
         DiagnosticStatus.__init__(self, *args, **kwds)
 
 
     def summary(self, *args):
-        """ Fills out the level and message fields of the DiagnosticStatus.
+        """ Fills out the level and message fields of the :diagnostic_msgs:`DiagnosticStatus`.
 
         Usage:
-        summary(diagnostic_status): Copies the summary from a DiagnosticStatus message
-        summary(lvl,msg): sets from lvl and messages
+
+        `summary(diagnostic_status)`: Copies the summary from a :diagnostic_msgs:`DiagnosticStatus` message
+
+        `summary(lvl,msg)`: sets from lvl and messages
         """
         if len(args)==1:
             self.level = args[0].level
@@ -94,10 +96,10 @@ class DiagnosticStatusWrapper(DiagnosticStatus):
     def mergeSummary(self, *args):
         """ Merges a level and message with the existing ones.
 
-        It is sometimes useful to merge two DiagnosticStatus messages. In that case,
+        It is sometimes useful to merge two :diagnostic_msgs:`DiagnosticStatus` messages. In that case,
         the key value pairs can be unioned, but the level and summary message
         have to be merged more intelligently. This function does the merge in
-        an intelligent manner, combining the summary in *this, with the one
+        an intelligent manner, combining the summary in this, with the one
         that is passed in.
 
         The combined level is the greater of the two levels to be merged.
@@ -107,8 +109,10 @@ class DiagnosticStatusWrapper(DiagnosticStatus):
         zero, the new message is ignored.
 
         Usage:
-        mergeSummary(diagnostic_status): merge from a DiagnosticStatus message
-        mergeSummary(lvl,msg): sets from lvl and msg
+
+        `mergeSummary(diagnostic_status)`: merge from a :diagnostic_msgs:`DiagnosticStatus` message
+
+        `mergeSummary(lvl,msg)`: sets from lvl and msg
         """
         if len(args)==1:
             lvl = args[0].level
@@ -131,13 +135,11 @@ class DiagnosticStatusWrapper(DiagnosticStatus):
     def add(self, key, val):
         """ Add a key-value pair.
 
-        This method adds a key-value pair. Any type that has a << stream
-        operator can be passed as the second argument.  Formatting is done
-        using a std::stringstream.
+        This method adds a key-value pair.
 
-        @type key string
-        @param key Key to be added.
-        @type value string
-        @param value Value to be added.
+        :type key: string
+        :param key: Key to be added.
+        :type any: string
+        :param value: Value to be added.
         """
         self.values.append(KeyValue(key,str(val)))

--- a/diagnostic_updater/src/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/src/diagnostic_updater/_diagnostic_updater.py
@@ -51,32 +51,40 @@ class DiagnosticTask:
     """DiagnosticTask is an abstract base class for collecting diagnostic data.
 
     Subclasses are provided for generating common diagnostic information.
-    A DiagnosticTask has a name, and a function that is called to create a
-    DiagnosticStatusWrapper.
+    A :class:`DiagnosticTask` has a name, and a function that is called to create a
+    :class:`DiagnosticStatusWrapper`.
     """
 
     def __init__(self, name):
-        """Constructs a DiagnosticTask setting its name in the process."""
+        """Constructs a :class:`DiagnosticTask` setting its name in the process.
+        
+        :param str name: The name of the diagnostic task.
+        """
         self.name = name
 
     def getName(self):
-        """Returns the name of the DiagnosticTask."""
+        """Returns the name of the :class:`DiagnosticTask`.
+        
+        :rtype: str
+        """
         return self.name
 
     def run(self, stat):
-        """Fills out this Task's DiagnosticStatusWrapper.
-        @param stat: the DiagnosticStatusWrapper to fill
-        @return the filled DiagnosticStatusWrapper
+        """Fills out this Task's :class:`DiagnosticStatusWrapper`.
+
+        :param DiagnosticStatusWrapper stat: the :class:`DiagnosticStatusWrapper` to fill
+        :return: the filled :class:`DiagnosticStatusWrapper`
+        :rtype: DiagnosticStatusWrapper
         """
         return stat
 
 
 
 class FunctionDiagnosticTask(DiagnosticTask):
-    """A DiagnosticTask based on a function.
+    """A :class:`DiagnosticTask` based on a function.
 
-    The FunctionDiagnosticTask calls the function when it updates. The
-    function updates the DiagnosticStatusWrapper and collects data.
+    The :class:`FunctionDiagnosticTask` calls the function when it updates. The
+    function updates the :class:`DiagnosticStatusWrapper` and collects data.
 
     This is useful for gathering information about a device or driver, like temperature,
     calibration, etc.
@@ -84,8 +92,9 @@ class FunctionDiagnosticTask(DiagnosticTask):
 
     def __init__(self, name, fn):
         """Constructs a GenericFunctionDiagnosticTask based on the given name and function.
-        @param name Name of the function.
-        @param fn Function to be called when run is called.
+
+        :param str name: Name of the function.
+        :param fn: Function to be called when run is called.
         """
         DiagnosticTask.__init__(self, name)
         self.fn = fn
@@ -96,24 +105,30 @@ class FunctionDiagnosticTask(DiagnosticTask):
 
 
 class CompositeDiagnosticTask(DiagnosticTask):
-    """Merges CompositeDiagnosticTask into a single DiagnosticTask.
+    """Merges :class:`CompositeDiagnosticTask` into a single :class:`DiagnosticTask`.
 
-    The CompositeDiagnosticTask allows multiple DiagnosticTask instances to
+    The :class:`CompositeDiagnosticTask` allows multiple :class:`DiagnosticTask` instances to
     be combined into a single task that produces a single
-    DiagnosticStatusWrapped. The output of the combination has the max of
+    :class:`DiagnosticStatusWrapper`. The output of the combination has the max of
     the status levels, and a concatenation of the non-zero-level messages.
 
     For instance, this could be used to combine the calibration and offset data
     from an IMU driver.
+    
+    :ivar tasks: List of tasks
+    :vartype tasks: list of :class:`DiagnosticTask`
     """
 
     def __init__(self, name):
-        """Constructs a CompositeDiagnosticTask with the given name."""
+        """Constructs a :class:`CompositeDiagnosticTask` with the given name.
+        
+        :param str name: The name of the diagnostic task.
+        """
         DiagnosticTask.__init__(self, name)
+
         self.tasks = []
 
     def run(self, stat):
-        """Runs each child and merges their outputs."""
         combined_summary = DiagnosticStatusWrapper()
         original_summary = DiagnosticStatusWrapper()
 
@@ -133,10 +148,12 @@ class CompositeDiagnosticTask(DiagnosticTask):
         return stat
 
     def addTask(self, t):
-        """Adds a child CompositeDiagnosticTask.
+        """Adds a child :class:`CompositeDiagnosticTask`.
 
-        This CompositeDiagnosticTask will be called each time this
-        CompositeDiagnosticTask is run.
+        This :class:`CompositeDiagnosticTask` will be called each time this
+        :class:`CompositeDiagnosticTask` is run.
+        
+        :param DiagnosticTask t: the :class:`DiagnosticTask` to add.
         """
         self.tasks.append(t)
 
@@ -145,15 +162,19 @@ class CompositeDiagnosticTask(DiagnosticTask):
 class DiagnosticTaskVector:
     """Internal use only.
 
-    Base class for diagnostic_updater::Updater and self_test::Dispatcher.
+    Base class for :class:`Updater` and self_test::Dispatcher.
     The class manages a collection of diagnostic updaters. It contains the
     common functionality used for producing diagnostic updates and for
     self-tests.
+    
+    :ivar tasks: List of tasks
+    :vartype tasks: list of :class:`DiagnosticTask`
+    :ivar threading.Lock lock: The lock protecting the enclosed list of tasks.
     """
 
     class DiagnosticTaskInternal:
         """Class used to represent a diagnostic task internally in
-        DiagnosticTaskVector.
+        :class:`DiagnosticTaskVector`.
         """
 
         def __init__(self, name, fn):
@@ -170,18 +191,22 @@ class DiagnosticTaskVector:
         self.lock = threading.Lock()
 
     def addedTaskCallback(self, task):
-        """Allows an action to be taken when a task is added. The Updater class
+        """Allows an action to be taken when a task is added. The :class:`Updater` class
         uses this to immediately publish a diagnostic that says that the node
         is loading.
+        
+        :param DiagnosticTask task: the added task.
         """
         pass
 
     def add(self, *args):
-        """Add a task to the DiagnosticTaskVector.
+        """Add a task to the :class:`DiagnosticTaskVector`.
 
         Usage:
-        add(task): where task is a DiagnosticTask
-        add(name, fn): add a DiagnosticTask embodied by a name and function
+
+        `add(task)`: where task is a DiagnosticTask
+
+        `add(name, fn)`: add a DiagnosticTask embodied by a name and function
         """
         if len(args)==1:
             task = DiagnosticTaskVector.DiagnosticTaskInternal(args[0].getName(), args[0].run)
@@ -198,8 +223,9 @@ class DiagnosticTaskVector:
         Removes the first task that matches the specified name. (New in
         version 1.1.2)
 
-        @param name Name of the task to remove.
-        @return Returns true if a task matched and was removed.
+        :param str name: Name of the task to remove.
+        :return: Returns true if a task matched and was removed.
+        :rtype: bool
         """
         found = False
         with self.lock:
@@ -220,7 +246,7 @@ class Updater(DiagnosticTaskVector):
     should be called frequently. At some predetermined rate, the update
     function will cause all the diagnostic tasks to run, and will collate
     and publish the resulting diagnostics. The publication rate is
-    determined by the "~diagnostic_period" ros parameter.
+    determined by the `~diagnostic_period` ros parameter.
 
     The class also allows an update to be forced when something significant
     has happened, and allows a single message to be broadcast on all the
@@ -291,8 +317,8 @@ class Updater(DiagnosticTaskVector):
 
         Useful if something drastic is happening such as shutdown or a self-test.
 
-        @param lvl Level of the diagnostic being output.
-        @param msg Status message to output.
+        :param int lvl: Level of the diagnostic being output.
+        :param str msg: Status message to output.
         """
 
         status_vec = []
@@ -306,10 +332,13 @@ class Updater(DiagnosticTaskVector):
         self.publish(status_vec)
 
     def setHardwareID(self, hwid):
+        """
+        :param str hwid: The hardware ID.
+        """
         self.hwid = hwid
 
     def _check_diagnostic_period(self):
-        """Recheck the diagnostic_period on the parameter server."""
+        """Recheck the `~diagnostic_period` on the parameter server."""
 
         # This was getParamCached() call in the cpp code. i.e. it would throttle
         # the actual call to the parameter server using a notification of change
@@ -326,7 +355,11 @@ class Updater(DiagnosticTaskVector):
                 pass
 
     def publish(self, msg):
-        """Publishes a single diagnostic status or a vector of diagnostic statuses."""
+        """Publishes a single diagnostic status or a vector of diagnostic statuses.
+        
+        :param msg: The status(es) to publish.
+        :type msg: diagnostic_msgs.msg.DiagnosticStatus
+        """
         if not type(msg) is list:
             msg = [msg]
 

--- a/diagnostic_updater/src/diagnostic_updater/_publisher.py
+++ b/diagnostic_updater/src/diagnostic_updater/_publisher.py
@@ -43,23 +43,23 @@ from ._update_functions import *
 
 class HeaderlessTopicDiagnostic(CompositeDiagnosticTask):
     """A class to facilitate making diagnostics for a topic using a
-    FrequencyStatus.
+    :class:`FrequencyStatus`.
 
     The word "headerless" in the class name refers to the fact that it is
     mainly designed for use with messages that do not have a header, and
-    that cannot therefore be checked using a TimeStampStatus.
+    that cannot therefore be checked using a :class:`TimeStampStatus`.
     """
 
     def __init__(self, name, diag, freq):
-        """Constructs a HeaderlessTopicDiagnostic.
+        """Constructs a :class:`HeaderlessTopicDiagnostic`.
 
-        @param name The name of the topic that is being diagnosed.
+        :param str name: The name of the topic that is being diagnosed.
 
-        @param diag The diagnostic_updater that the CompositeDiagnosticTask
-        should add itself to.
+        :param diagnostic_updater.Updater diag: The :class:`Updater` that the :class:`CompositeDiagnosticTask`
+                                                should add itself to.
 
-        @param freq The parameters for the FrequencyStatus class that will be
-        computing statistics.
+        :param diagnostic_updater.FrequencyStatusParam freq: The parameters for the :class:`FrequencyStatus`
+                                                             class that will be computing statistics.
         """
         CompositeDiagnosticTask.__init__(self, name + " topic status")
         self.diag = diag
@@ -78,22 +78,22 @@ class HeaderlessTopicDiagnostic(CompositeDiagnosticTask):
 
 class TopicDiagnostic(HeaderlessTopicDiagnostic):
     """A class to facilitate making diagnostics for a topic using a
-    FrequencyStatus and TimeStampStatus.
+    :class:`FrequencyStatus` and :class:`TimeStampStatus`.
     """
 
     def __init__(self, name, diag, freq, stamp):
-        """Constructs a TopicDiagnostic.
+        """Constructs a :class:`TopicDiagnostic`.
 
-        @param name The name of the topic that is being diagnosed.
+        :param str name: The name of the topic that is being diagnosed.
 
-        @param diag The diagnostic_updater that the CompositeDiagnosticTask
-        should add itself to.
+        :param diagnostic_updater.Updater diag: The :class:`Updater` that the :class:`CompositeDiagnosticTask`
+                                                should add itself to.
 
-        @param freq The parameters for the FrequencyStatus class that will be
-        computing statistics.
+        :param diagnostic_updater.FrequencyStatusParam freq: The parameters for the :class:`FrequencyStatus`
+                                                             class that will be computing statistics.
 
-        @param stamp The parameters for the TimeStampStatus class that will be
-        computing statistics.
+        :param diagnostic_updater.TimeStampStatusParam stamp: The parameters for the :class:`TimeStampStatus`
+                                                              class that will be computing statistics.
         """
 
         HeaderlessTopicDiagnostic.__init__(self, name, diag, freq)
@@ -103,33 +103,34 @@ class TopicDiagnostic(HeaderlessTopicDiagnostic):
     def tick(self, stamp):
         """Collects statistics and publishes the message.
 
-        @param stamp Timestamp to use for interval computation by the
-        TimeStampStatus class.
+        :param stamp: Timestamp to use for interval computation by the
+                      :class:`TimeStampStatus` class.
+        :type stamp: float or rospy.Time
         """
         self.stamp.tick(stamp)
         HeaderlessTopicDiagnostic.tick(self)
 
 
 class DiagnosedPublisher(TopicDiagnostic):
-    """A TopicDiagnostic combined with a ros::Publisher.
+    """A :class:`TopicDiagnostic` combined with a :class:`rospy.Publisher`.
 
-    For a standard ros::Publisher, this class allows the ros::Publisher and
-    the TopicDiagnostic to be combined for added convenience.
+    For a standard :class:`rospy.Publisher`, this class allows the :class:`rospy.Publisher` and
+    the :class:`TopicDiagnostic` to be combined for added convenience.
     """
 
     def __init__(self, pub, diag, freq, stamp):
-        """Constructs a DiagnosedPublisher.
+        """Constructs a :class:`DiagnosedPublisher`.
 
-        @param pub The publisher on which statistics are being collected.
+        :param rospy.Publisher pub: The publisher on which statistics are being collected.
 
-        @param diag The diagnostic_updater that the CompositeDiagnosticTask
-        should add itself to.
+        :param diagnostic_updater.Updater diag: The :class:`Updater` that the :class:`CompositeDiagnosticTask`
+                                                should add itself to.
 
-        @param freq The parameters for the FrequencyStatus class that will be
-        computing statistics.
+        :param diagnostic_updater.FrequencyStatusParam freq: The parameters for the :class:`FrequencyStatus`
+                                                             class that will be computing statistics.
 
-        @param stamp The parameters for the TimeStampStatus class that will be
-        computing statistics.
+        :param diagnostic_updater.TimeStampStatusParam stamp: The parameters for the :class:`TimeStampStatus`
+                                                              class that will be computing statistics.
         """
         TopicDiagnostic.__init__(self, pub.name, diag, freq, stamp)
         self.publisher = pub
@@ -137,8 +138,10 @@ class DiagnosedPublisher(TopicDiagnostic):
     def publish(self, message):
         """Collects statistics and publishes the message.
 
-        The timestamp to be used by the TimeStampStatus class will be
-        extracted from message.header.stamp.
+        The timestamp to be used by the :class:`TimeStampStatus` class will be
+        extracted from `message.header.stamp`.
+        
+        :param genpy.Message message: The message to be published.
         """
         self.tick(message.header.stamp)
         self.publisher.publish(message)

--- a/diagnostic_updater/src/diagnostic_updater/_update_functions.py
+++ b/diagnostic_updater/src/diagnostic_updater/_update_functions.py
@@ -44,24 +44,36 @@ class FrequencyStatusParam:
     """A structure that holds the constructor parameters for the FrequencyStatus
     class.
 
-    Implementation note: the min_freq and max_freq parameters in the C += 1 code
+    Implementation note: the `min_freq` and `max_freq` parameters in the C++ code
     are stored as pointers, so that if they are updated, the new values are used.
     To emulate this behavior, we here use a dictionary to hold them: {'min','max'}
 
-    freq_bound is a dictionary with keys 'min' and 'max', containing the min
-    and max acceptable frequencies.
+    :ivar dict freq_bound: Dictionary with keys `min` and `max`, containing the min
+                           and max acceptable frequencies.
 
-    tolerance is the tolerance with which bounds must be satisfied. Acceptable
-    values are from freq_bound['min'] * (1 - torelance) to
-    freq_bound['max'] * (1 + tolerance). Common use cases are to set
-    tolerance to zero, or to assign the same value to freq_bound['min'] and
-    freq_bound['max']
+    :ivar float tolerance: The tolerance with which bounds must be satisfied. Acceptable
+                           values are from `freq_bound['min'] * (1 - torelance)` to
+                           `freq_bound['max'] * (1 + tolerance)`. Common use cases are to set
+                           tolerance to zero, or to assign the same value to `freq_bound['min']` and
+                           `freq_bound['max']`.
 
-    window_size is the number of events to consider in the statistics.
+    :ivar int window_size: The number of events to consider in the statistics.
     """
 
     def __init__(self, freq_bound, tolerance = 0.1, window_size = 5):
-        """Creates a filled-out FrequencyStatusParam."""
+        """Creates a filled-out :class:`FrequencyStatusParam`.
+        
+        :param dict freq_bound: Dictionary with keys `min` and `max`, containing the min
+                                and max acceptable frequencies.
+        
+        :param float tolerance: The tolerance with which bounds must be satisfied. Acceptable
+                                values are from `freq_bound['min'] * (1 - torelance)` to
+                                `freq_bound['max'] * (1 + tolerance)`. Common use cases are to set
+                                tolerance to zero, or to assign the same value to `freq_bound['min']` and
+                                `freq_bound['max']`.
+    
+        :param int window_size: The number of events to consider in the statistics.
+        """
         self.freq_bound = freq_bound
         self.tolerance = tolerance
         self.window_size = window_size
@@ -77,7 +89,11 @@ class FrequencyStatus(DiagnosticTask):
     """
 
     def __init__(self, params, name = "FrequencyStatus"):
-        """Constructs a FrequencyStatus class with the given parameters."""
+        """Constructs a FrequencyStatus class with the given parameters.
+        
+        :param FrequencyStatus params: parameters of the diagnostic task.
+        :param str name: name of the diagnostic task.
+        """
         DiagnosticTask.__init__(self, name)
         self.params = params
         self.lock = threading.Lock()
@@ -132,14 +148,18 @@ class FrequencyStatus(DiagnosticTask):
 
 
 class TimeStampStatusParam:
-    """A structure that holds the constructor parameters for the TimeStampStatus class.
+    """A structure that holds the constructor parameters for the :class:`TimeStampStatus` class.
 
-    max_acceptable: maximum acceptable difference between two timestamps.
-    min_acceptable: minimum acceptable difference between two timestamps.
+    :ivar float max_acceptable: maximum acceptable difference between two timestamps.
+    :ivar float min_acceptable: minimum acceptable difference between two timestamps.
     """
 
     def __init__(self, min_acceptable = -1, max_acceptable = 5):
-        """Creates a filled-out TimeStampStatusParam."""
+        """Creates a filled-out :class:`TimeStampStatusParam`.
+        
+        :param float min_acceptable: minimum acceptable difference between two timestamps. 
+        :param float max_acceptable: maximum acceptable difference between two timestamps. 
+        """
         self.max_acceptable = max_acceptable
         self.min_acceptable = min_acceptable
 
@@ -156,7 +176,11 @@ class TimeStampStatus(DiagnosticTask):
     """
 
     def __init__(self, params = TimeStampStatusParam(), name = "Timestamp Status"):
-        """Constructs the TimeStampStatus with the given parameters."""
+        """Constructs the :class:`TimeStampStatus` with the given parameters.
+        
+        :param TimeStampStatus params: parameters of the diagnostic task.
+        :param str name: name of the diagnostic task.
+        """
         DiagnosticTask.__init__(self, name)
         self.params = params
         self.lock = threading.Lock()
@@ -170,8 +194,9 @@ class TimeStampStatus(DiagnosticTask):
 
     def tick(self, stamp):
         """Signals an event.
-        @param stamp The timestamp of the event that will be used in computing
-        intervals. Can be either a double or a ros::Time.
+
+        :param stamp: The timestamp of the event that will be used in computing intervals.
+        :type stamp: float or rospy.Time.
         """
         if not isinstance(stamp, float):
             stamp = stamp.to_sec()


### PR DESCRIPTION
I've added a Sphinx config to generate Python docs for the diagnostic_updater package.

To retain references to the C++ API, I haven't generated the standard disambiguation page with C++/Python/Msg links, but I've kept C++ API docs in the original path, generated Python into a subfolder, and added a link to the Python API docs to the C++ docs.

The behavior of the code should not change, although I've added the `__all__` variable to `__init__.py` to convince Sphinx to generate the package-level docs.