### PR TITLE
fix: replace deprecated MessageUniquePtr 

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -242,7 +242,7 @@ public:
    * The timestamp to be used by the TimeStampStatus class will be
    * extracted from message.header.stamp.
    */
-  virtual void publish(typename PublisherT::MessageUniquePtr message)
+  virtual void publish(std::unique_ptr<typename PublisherT::ROSMessageType, typename PublisherT::ROSMessageTypeDeleter> message)
   {
     tick(message->header.stamp);
     publisher_->publish(std::move(message));

--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -242,7 +242,9 @@ public:
    * The timestamp to be used by the TimeStampStatus class will be
    * extracted from message.header.stamp.
    */
-  virtual void publish(std::unique_ptr<typename PublisherT::ROSMessageType, typename PublisherT::ROSMessageTypeDeleter> message)
+  virtual void publish(
+    std::unique_ptr<typename PublisherT::ROSMessageType,
+    typename PublisherT::ROSMessageTypeDeleter> message)
   {
     tick(message->header.stamp);
     publisher_->publish(std::move(message));


### PR DESCRIPTION
Hi! Here is a fix PR.

According to this PR https://github.com/ros2/rclcpp/commit/bdf1f8f78a95bb59c4549465300fd0a11867f137#diff-120be1036dd45a9b14efb6c9c5fd7d5f338869abc13a7d05067ea70183353e8bL109. `MessageUniquePtr` should be changed to `std::unique_ptr<PublishedType, PublishedTypeDeleter>` to keep the project going well.