### PR TITLE
Add missing rclpy dependency to common_diagnostics to fix rosdoc2 output

### DIFF
--- a/diagnostic_common_diagnostics/package.xml
+++ b/diagnostic_common_diagnostics/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>lm-sensors</exec_depend>
   <exec_depend>python3-ntplib</exec_depend>
   <exec_depend>python3-psutil</exec_depend>
+  <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <!-- Usage of ament_lint_common is locked by https://github.com/ament/ament_lint/issues/423


### PR DESCRIPTION
Hi, current maintainer of rosdoc2 here. I enjoyed the talk on diagnostics at ROSCON 2024, so I thought I would try to figure out why some documentation is missing. Turns out to be pretty straightforward: a missing dependency.

You should see at https://docs.ros.org/en/rolling/p/diagnostic_common_diagnostics/diagnostic_common_diagnostics.html that all of the submodule python documentation is missing. This PR fixes it in my fork.