### PR TITLE
[ros2-iron] Add missing rclpy dependency to common_diagnostics to fix rosdoc2 output (#402)

### DIFF
--- a/diagnostic_common_diagnostics/package.xml
+++ b/diagnostic_common_diagnostics/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>lm-sensors</exec_depend>
   <exec_depend>python3-ntplib</exec_depend>
   <exec_depend>python3-psutil</exec_depend>
+  <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <!-- Usage of ament_lint_common is locked by https://github.com/ament/ament_lint/issues/423


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-iron`:
 - [Add missing rclpy dependency to common_diagnostics to fix rosdoc2 output (#402)](https://github.com/ros/diagnostics/pull/402)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)