### PR TITLE
[ros2-humble] Skipping flaky ntp test (#409)

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -84,28 +84,29 @@ if(BUILD_TESTING)
   file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}/aggregator_node" AGGREGATOR_NODE)
   file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}/add_analyzer" ADD_ANALYZER)
   file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/test_listener.py" TEST_LISTENER)
-  set(create_analyzers_tests
-    "primitive_analyzers"
-    "all_analyzers"
-    "analyzer_group"
-    "empty_root_path")
+  # SKIPPING FLAKY TEST
+  # set(create_analyzers_tests
+  #   "primitive_analyzers"
+  #   "all_analyzers"
+  #   "analyzer_group"
+  #   "empty_root_path")
 
-  foreach(test_name ${create_analyzers_tests})
-    file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/${test_name}.yaml" PARAMETER_FILE)
-    file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/expected_output/create_${test_name}" EXPECTED_OUTPUT)
+  # foreach(test_name ${create_analyzers_tests})
+  #   file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/${test_name}.yaml" PARAMETER_FILE)
+  #   file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/expected_output/create_${test_name}" EXPECTED_OUTPUT)
 
-    configure_file(
-      "test/create_analyzers.launch.py.in"
-      "test_create_${test_name}.launch.py"
-      @ONLY
-    )
-    add_launch_test(
-      "${CMAKE_CURRENT_BINARY_DIR}/test_create_${test_name}.launch.py"
-      TARGET "test_create_${test_name}"
-      TIMEOUT 30
-      ENV
-    )
-  endforeach()
+  #   configure_file(
+  #     "test/create_analyzers.launch.py.in"
+  #     "test_create_${test_name}.launch.py"
+  #     @ONLY
+  #   )
+  #   add_launch_test(
+  #     "${CMAKE_CURRENT_BINARY_DIR}/test_create_${test_name}.launch.py"
+  #     TARGET "test_create_${test_name}"
+  #     TIMEOUT 30
+  #     ENV
+  #   )
+  # endforeach()
 
   set(analyzers_output_tests
     "primitive_analyzers"

--- a/diagnostic_common_diagnostics/CMakeLists.txt
+++ b/diagnostic_common_diagnostics/CMakeLists.txt
@@ -26,10 +26,11 @@ if(BUILD_TESTING)
         test_cpu_monitor
         test/systemtest/test_cpu_monitor.py
         TIMEOUT 10)
-    add_launch_test(
-        test/systemtest/test_ntp_monitor_launchtest.py
-        TARGET ntp_monitor_launchtest
-        TIMEOUT 20)
+    # SKIPPING FLAKY TEST
+    # add_launch_test(
+    #     test/systemtest/test_ntp_monitor_launchtest.py
+    #     TARGET ntp_monitor_launchtest
+    #     TIMEOUT 20)
     add_launch_test(
         test/systemtest/test_hd_monitor_launchtest.py
         TARGET hd_monitor_launchtest


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-humble`:
 - [Skipping flaky ntp test (#409)](https://github.com/ros/diagnostics/pull/409)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)