### PR TITLE
[ros2-iron] Skipping flaky tests (#413)

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -151,15 +151,17 @@ if(BUILD_TESTING)
     )
   endforeach()
 
-  add_launch_test(
-    test/test_critical_pub.py
-    TIMEOUT 30
-  )
+  # SKIPPING FLAKY TEST
+  # add_launch_test(
+  #   test/test_critical_pub.py
+  #   TIMEOUT 30
+  # )
 
-  ament_add_pytest_test(test_discard_behavior
-    "${CMAKE_CURRENT_SOURCE_DIR}/test/test_discard_behavior.py"
-    TIMEOUT 60
-  )
+  # SKIPPING FLAKY TEST
+  # ament_add_pytest_test(test_discard_behavior
+  #   "${CMAKE_CURRENT_SOURCE_DIR}/test/test_discard_behavior.py"
+  #   TIMEOUT 60
+  # )
 endif()
 
 install(

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -84,22 +84,19 @@ if(BUILD_TESTING)
     "rclcpp_lifecycle"
     "std_msgs"
   )
-  ament_add_gtest(status_msg_test test/status_msg_test.cpp)
-  target_include_directories(status_msg_test
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-  )
-  ament_target_dependencies(
-    status_msg_test
-    "diagnostic_msgs"
-    "rclcpp"
-  )
+  # SKIPPING FLAKY TEST
+  # ament_add_gtest(status_msg_test test/status_msg_test.cpp)
+  # target_include_directories(status_msg_test
+  #   PUBLIC
+  #   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  #   $<INSTALL_INTERFACE:include>
+  # )
+  # target_link_libraries(status_msg_test ${PROJECT_NAME})
 
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(diagnostic_updater_test.py "test/diagnostic_updater_test.py")
   ament_add_pytest_test(test_DiagnosticStatusWrapper.py "test/test_diagnostic_status_wrapper.py")
-  ament_add_pytest_test(status_msg_test.py "test/status_msg_test.py")
+  # ament_add_pytest_test(status_msg_test.py "test/status_msg_test.py")
 endif()
 
 ament_python_install_package(${PROJECT_NAME})


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-iron`:
 - [Skipping flaky tests (#413)](https://github.com/ros/diagnostics/pull/413)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)