### PR TITLE
Support custom `rclcpp::NodeOptions`

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -111,6 +111,13 @@ public:
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   Aggregator();
 
+  /*!
+   *\brief Constructor initializes with main prefix (ex: '/Robot') and custom node options
+   */
+  DIAGNOSTIC_AGGREGATOR_PUBLIC
+  Aggregator(const rclcpp::NodeOptions & options);
+
+
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   virtual ~Aggregator();
 

--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -115,7 +115,7 @@ public:
    *\brief Constructor initializes with main prefix (ex: '/Robot') and custom node options
    */
   DIAGNOSTIC_AGGREGATOR_PUBLIC
-  Aggregator(rclcpp::NodeOptions options);
+  explicit Aggregator(rclcpp::NodeOptions options);
 
 
   DIAGNOSTIC_AGGREGATOR_PUBLIC

--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -115,7 +115,7 @@ public:
    *\brief Constructor initializes with main prefix (ex: '/Robot') and custom node options
    */
   DIAGNOSTIC_AGGREGATOR_PUBLIC
-  Aggregator(const rclcpp::NodeOptions & options);
+  Aggregator(rclcpp::NodeOptions options);
 
 
   DIAGNOSTIC_AGGREGATOR_PUBLIC

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -59,7 +59,7 @@ using diagnostic_msgs::msg::DiagnosticStatus;
 Aggregator::Aggregator()
 : Aggregator(rclcpp::NodeOptions()) {}
 
-Aggregator::Aggregator(const rclcpp::NodeOptions & options)
+Aggregator::Aggregator(rclcpp::NodeOptions options)
 : n_(std::make_shared<rclcpp::Node>(
       "analyzers", "",
       options.allow_undeclared_parameters(true).

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -57,9 +57,12 @@ using diagnostic_msgs::msg::DiagnosticStatus;
  * @todo(anordman): make aggregator a lifecycle node.
  */
 Aggregator::Aggregator()
+: Aggregator(rclcpp::NodeOptions()) {}
+
+Aggregator::Aggregator(const rclcpp::NodeOptions & options)
 : n_(std::make_shared<rclcpp::Node>(
       "analyzers", "",
-      rclcpp::NodeOptions().allow_undeclared_parameters(true).
+      options.allow_undeclared_parameters(true).
       automatically_declare_parameters_from_overrides(true))),
   logger_(rclcpp::get_logger("Aggregator")),
   pub_rate_(1.0),


### PR DESCRIPTION
This eases static composition of multiple ROS 2 nodes