### PR TITLE
[ros2-jazzy] common_diagnostics cleaned hostname string (#405)

### DIFF
--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/cpu_monitor.py
@@ -92,7 +92,11 @@ def main(args=None):
 
     # Create the node
     hostname = socket.gethostname()
-    node = Node(f'cpu_monitor_{hostname.replace("-", "_")}')
+    # Every invalid symbol is replaced by underscore.
+    # isalnum() alone also allows invalid symbols depending on the locale
+    cleaned_hostname = ''.join(
+        c if (c.isascii() and c.isalnum()) else '_' for c in hostname)
+    node = Node(f'cpu_monitor_{cleaned_hostname}')
 
     # Declare and get parameters
     node.declare_parameter('warning_percentage', 90)

--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/hd_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/hd_monitor.py
@@ -74,8 +74,12 @@ class HDMonitor(Node):
     """
 
     def __init__(self):
-        hostname = gethostname().replace('.', '_').replace('-', '_')
-        super().__init__(f'hd_monitor_{hostname}')
+        hostname = gethostname()
+        # Every invalid symbol is replaced by underscore.
+        # isalnum() alone also allows invalid symbols depending on the locale
+        cleaned_hostname = ''.join(
+            c if (c.isascii() and c.isalnum()) else '_' for c in hostname)
+        super().__init__(f'hd_monitor_{cleaned_hostname}')
 
         self._path = '~'
         self._free_percent_low = 0.05

--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/ram_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/ram_monitor.py
@@ -72,8 +72,12 @@ class RamTask(DiagnosticTask):
 
 def main():
     hostname = socket.gethostname()
+    # Every invalid symbol is replaced by underscore.
+    # isalnum() alone also allows invalid symbols depending on the locale
+    cleaned_hostname = ''.join(
+        c if (c.isascii() and c.isalnum()) else '_' for c in hostname)
     rclpy.init()
-    node = rclpy.create_node(f'ram_monitor_{hostname.replace("-", "_")}')
+    node = rclpy.create_node(f'ram_monitor_{cleaned_hostname}')
 
     updater = Updater(node)
     updater.setHardwareID(hostname)

--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/sensors_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/sensors_monitor.py
@@ -245,8 +245,11 @@ class SensorsMonitor(object):
 if __name__ == '__main__':
     rclpy.init()
     hostname = socket.gethostname()
-    hostname_clean = hostname.translate(hostname.maketrans('-', '_'))
-    node = rclpy.create_node('sensors_monitor_%s' % hostname_clean)
+    # Every invalid symbol is replaced by underscore.
+    # isalnum() alone also allows invalid symbols depending on the locale
+    cleaned_hostname = ''.join(
+        c if (c.isascii() and c.isalnum()) else '_' for c in hostname)
+    node = rclpy.create_node('sensors_monitor_%s' % cleaned_hostname)
 
     monitor = SensorsMonitor(node, hostname)
     try:


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-jazzy`:
 - [common_diagnostics cleaned hostname string (#405)](https://github.com/ros/diagnostics/pull/405)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)