### PR TITLE
[ros2-iron] Support custom `rclcpp::NodeOptions` (#417)

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -111,6 +111,13 @@ public:
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   Aggregator();
 
+  /*!
+   *\brief Constructor initializes with main prefix (ex: '/Robot') and custom node options
+   */
+  DIAGNOSTIC_AGGREGATOR_PUBLIC
+  explicit Aggregator(rclcpp::NodeOptions options);
+
+
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   virtual ~Aggregator();
 

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -57,9 +57,12 @@ using diagnostic_msgs::msg::DiagnosticStatus;
  * @todo(anordman): make aggregator a lifecycle node.
  */
 Aggregator::Aggregator()
+: Aggregator(rclcpp::NodeOptions()) {}
+
+Aggregator::Aggregator(rclcpp::NodeOptions options)
 : n_(std::make_shared<rclcpp::Node>(
       "analyzers", "",
-      rclcpp::NodeOptions().allow_undeclared_parameters(true).
+      options.allow_undeclared_parameters(true).
       automatically_declare_parameters_from_overrides(true))),
   logger_(rclcpp::get_logger("Aggregator")),
   pub_rate_(1.0),


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-iron`:
 - [Support custom &#x60;rclcpp::NodeOptions&#x60; (#417)](https://github.com/ros/diagnostics/pull/417)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)