### PR TITLE
Add Windows support

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 find_package(ament_cmake REQUIRED)
 find_package(diagnostic_msgs REQUIRED)

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)


### PR DESCRIPTION
The packages in this repo compile shared libraries, but does not expose any symbol on Windows, so no library is actually generated on Windows.

On Linux and macOS, everything compiles fine as by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable, so this PR sets the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` variable to `ON`, to ensure that the compilation works fine on Windows.