### PR TITLE
Don't use `match`

### DIFF
--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/hd_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/hd_monitor.py
@@ -101,15 +101,14 @@ class HDMonitor(Node):
         see the class documentation for declared parameters.
         """
         for param in params:
-            match param.name:
-                case 'path':
-                    self._path = str(
-                        Path(param.value).expanduser().resolve(strict=True)
-                    )
-                case 'free_percent_low':
-                    self._free_percent_low = param.value
-                case 'free_percent_crit':
-                    self._free_percent_crit = param.value
+            if param.name == 'path':
+                self._path = str(
+                    Path(param.value).expanduser().resolve(strict=True)
+                )
+            elif param.name == 'free_percent_low':
+                self._free_percent_low = param.value
+            elif param.name == 'free_percent_crit':
+                self._free_percent_crit = param.value
 
         return SetParametersResult(successful=True)
 


### PR DESCRIPTION
The match-case was introduced with python 3.10, but except for Ubuntu 10 one can't expect this python version. https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027
I struggled running that on Debian Bullseye.