### PR TITLE
[ros2-jazzy] Grafana Integration (#425)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,6 +41,7 @@ jobs:
           package-name: |
             diagnostic_aggregator
             diagnostic_common_diagnostics
+            diagnostic_remote_logging
             diagnostic_updater
             self_test
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
         package: [
             diagnostic_aggregator,
             diagnostic_common_diagnostics,
+            diagnostic_remote_logging,
             diagnostic_updater,
             self_test,
           ]

--- a/diagnostic_remote_logging/CMakeLists.txt
+++ b/diagnostic_remote_logging/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(diagnostic_remote_logging)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(dependencies
+    ament_cmake
+    rclcpp
+    rclcpp_components
+    diagnostic_msgs
+    CURL
+)
+
+foreach(dep ${dependencies})
+    find_package(${dep} REQUIRED)
+endforeach(dep)
+
+include_directories(
+    src/
+    include/
+)
+add_library(influx_component SHARED src/influxdb.cpp)
+
+ament_target_dependencies(influx_component ${dependencies})
+
+ament_export_dependencies(influx_component ${dependencies})
+
+target_compile_features(influx_component PUBLIC c_std_99 cxx_std_17)
+
+rclcpp_components_register_node(
+    influx_component
+    PLUGIN "InfluxDB"
+    EXECUTABLE influx
+)
+ament_export_targets(export_influx_component)
+install(TARGETS influx_component
+        EXPORT export_influx_component
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+)
+
+if(BUILD_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
+    ament_add_gtest(unit_tests test/influx_line_protocol.cpp)
+    target_include_directories(unit_tests PRIVATE include)
+    target_link_libraries(unit_tests influx_component)
+    ament_target_dependencies(unit_tests ${dependencies} ament_cmake_gtest)
+endif()
+ament_package()

--- a/diagnostic_remote_logging/CMakeLists.txt.uncrustify
+++ b/diagnostic_remote_logging/CMakeLists.txt.uncrustify
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(diagnostic_remote_logging)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall - Wextra - Wpedantic)
+  endif()
+
+  set(dependencies
+    ament_cmake
+    rclcpp
+    rclcpp_components
+    diagnostic_msgs
+    CURL
+  )
+
+  foreach(dep $ {dependencies})
+  find_package($ {dep} REQUIRED)
+  endforeach(dep)
+
+  include_directories(
+    src /
+    include /
+  )
+  add_library(influx_component SHARED src / influxdb.cpp)
+
+  ament_target_dependencies(influx_component $ {dependencies})
+
+  ament_export_dependencies(influx_component $ {dependencies})
+
+  target_compile_features(influx_component PUBLIC c_std_99 cxx_std_17)
+
+  rclcpp_components_register_node(
+    influx_component
+    PLUGIN "InfluxDB"
+    EXECUTABLE influx
+  )
+  ament_export_targets(export_influx_component)
+  install(TARGETS influx_component
+        EXPORT export_influx_component
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+  )
+
+  if(BUILD_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
+    ament_add_gtest(unit_tests test / influx_line_protocol.cpp)
+    target_include_directories(unit_tests PRIVATE include)
+    target_link_libraries(unit_tests influx_component)
+    ament_target_dependencies(unit_tests $ {dependencies} ament_cmake_gtest)
+    endif()
+    ament_package()

--- a/diagnostic_remote_logging/CMakeLists.txt.uncrustify.uncrustify
+++ b/diagnostic_remote_logging/CMakeLists.txt.uncrustify.uncrustify
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(diagnostic_remote_logging)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall - Wextra - Wpedantic)
+  endif()
+
+  set(dependencies
+    ament_cmake
+    rclcpp
+    rclcpp_components
+    diagnostic_msgs
+    CURL
+  )
+
+  foreach(dep $ {dependencies})
+  find_package($ {dep} REQUIRED)
+  endforeach(dep)
+
+  include_directories(
+    src /
+    include /
+  )
+  add_library(influx_component SHARED src / influxdb.cpp)
+
+  ament_target_dependencies(influx_component $ {dependencies})
+
+  ament_export_dependencies(influx_component $ {dependencies})
+
+  target_compile_features(influx_component PUBLIC c_std_99 cxx_std_17)
+
+  rclcpp_components_register_node(
+    influx_component
+    PLUGIN "InfluxDB"
+    EXECUTABLE influx
+  )
+  ament_export_targets(export_influx_component)
+  install(TARGETS influx_component
+        EXPORT export_influx_component
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+  )
+
+  if(BUILD_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
+    ament_add_gtest(unit_tests test / influx_line_protocol.cpp)
+    target_include_directories(unit_tests PRIVATE include)
+    target_link_libraries(unit_tests influx_component)
+    ament_target_dependencies(unit_tests $ {dependencies} ament_cmake_gtest)
+    endif()
+    ament_package()

--- a/diagnostic_remote_logging/README.md
+++ b/diagnostic_remote_logging/README.md
@@ -1,0 +1,81 @@
+General information about this repository, including legal information and known issues/limitations, are given in [README.md](../README.md) in the repository root.
+
+# The diagnostic_remote_logging package
+
+This package provides the `influx` node, which listens to diagnostic messages and integrates with InfluxDB v2 for monitoring and visualization. Specifically, it subscribes to the [`diagnostic_msgs/DiagnosticArray`](https://index.ros.org/p/diagnostic_msgs) messages on the `/diagnostics_agg` topic and the [`diagnostic_msgs/DiagnosticStatus`](https://index.ros.org/p/diagnostic_msgs) messages on the `/diagnostics_toplevel_state` topic. The node processes these messages, sending their statistics and levels to an [`InfluxDB`](http://influxdb.com) database, enabling use with tools like [`Grafana`](https://grafana.com).
+
+As of now we only support InfluxDB v2, for support with older versions please use a proxy like [`Telegraf`](https://www.influxdata.com/time-series-platform/telegraf/). See section [Telegraf](#using-a-telegraf-proxy) for an example on how to setup.
+
+## Node Configuration
+
+You can send data to [`InfluxDB`](http://influxdb.com) in two ways: directly to the database or via a proxy like [`Telegraf`](https://www.influxdata.com/time-series-platform/telegraf/). While both methods are valid, using a proxy is generally recommended due to the following benefits:
+
+- **Efficient Data Transmission**: Telegraf aggregates multiple measurements and sends them in a single request, reducing bandwidth usage and minimizing database load.
+- **Enhanced Reliability**: Provides buffering in case of connection issues, ensuring no data is lost.
+- **Comprehensive Metric Collection**: Telegraf can send additional system metrics (e.g., RAM, CPU, network usage) with minimal configuration.
+- **Data Filtering and Transformation**: Supports preprocessing, such as filtering or transforming data, before sending it to InfluxDB.
+
+To use either method, ensure you have a running instance of InfluxDB. The simplest way to set this up is through [`InfluxDB Cloud`](https://cloud2.influxdata.com/signup).
+
+### Parameters
+
+The `influx` node supports several parameters. Below is an example configuration:
+
+```yaml
+/influx:
+  ros__parameters:
+    connection:
+      url: http://localhost:8086/api/v2/write
+      token:
+      bucket:
+      organization:
+    send:
+      agg: true
+      top_level_state: true
+```
+
+- `send.agg`: Enables or disables subscription to the `/diagnostics_agg` topic.
+- `send.top_level_state`: Enables or disables subscription to the `/diagnostics_toplevel_state` topic.
+
+#### InfluxDB Configuration
+
+Set the following parameters in your configuration to match your InfluxDB instance:
+
+- `connection.url`: The URL of your InfluxDB write API endpoint.
+- `connection.token`: Your InfluxDB authentication token.
+- `connection.bucket`: The target bucket in InfluxDB.
+- `connection.organization`: The name of your InfluxDB organization.
+
+### Starting the node
+
+Afterward all configurations are set run the node with the following command:
+
+```bash
+ros2 run diagnostic_remote_logging influx --ros-args --params-file <path_to_yaml_file>
+```
+
+## Using a Telegraf Proxy
+
+To configure Telegraf as a proxy for InfluxDB:
+
+1. Ensure Telegraf is set up to send data to your InfluxDB instance via its configuration file (`/etc/telegraf/telegraf.conf`). Check [this link](https://docs.influxdata.com/influxdb/cloud/write-data/no-code/use-telegraf/manual-config/) for an example.
+2. Add the following to the telegraf configuration file to enable the InfluxDB v2 listener:
+
+    ```toml
+    [[inputs.influxdb_v2_listener]]
+      service_address = ":8086"
+    ```
+
+3. Update the `influx` node configuration to point to the appropriate URL. For example, if Telegraf is running on the same host as the `influx` node, the default `http://localhost:8086/api/v2/write` should work.
+
+4. Leave the following parameters empty in the `influx` node configuration when using Telegraf as a proxy:
+
+    - `connection.token`
+    - `connection.bucket`
+    - `connection.organization`
+
+5. Afterwards run the node with the following command:
+
+    ```bash
+    ros2 run diagnostic_remote_logging influx --ros-args --params-file <path_to_yaml_file>
+    ```

--- a/diagnostic_remote_logging/include/diagnostic_remote_logging/influx_line_protocol.hpp
+++ b/diagnostic_remote_logging/include/diagnostic_remote_logging/influx_line_protocol.hpp
@@ -1,0 +1,172 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, Daan Wijffels
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/**
+ * \author Daan Wijffels
+ */
+
+#ifndef DIAGNOSTIC_REMOTE_LOGGING__INFLUX_LINE_PROTOCOL_HPP_
+#define DIAGNOSTIC_REMOTE_LOGGING__INFLUX_LINE_PROTOCOL_HPP_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+
+std::string toInfluxTimestamp(const rclcpp::Time & time)
+{
+  uint64_t seconds = static_cast<uint64_t>(time.seconds());
+  uint64_t nanoseconds = static_cast<uint64_t>(time.nanoseconds()) % 1000000000;
+
+  // Convert to strings
+  std::string secStr = std::to_string(seconds);
+  std::string nanosecStr = std::to_string(nanoseconds);
+
+  // Zero-pad nanoseconds to 9 digits
+  nanosecStr = std::string(9 - nanosecStr.length(), '0') + nanosecStr;
+
+  return secStr + nanosecStr;
+}
+
+std::string escapeSpace(const std::string & input)
+{
+  std::string result;
+  for (char c : input) {
+    if (c == ' ') {
+      result += '\\';  // Add a backslash before the space
+    }
+    result += c;  // Add the original character
+  }
+  return result;
+}
+
+bool is_number(const std::string & s)
+{
+  std::istringstream iss(s);
+  double d;
+  return iss >> std::noskipws >> d && iss.eof();
+}
+
+std::string formatValues(const std::vector<diagnostic_msgs::msg::KeyValue> & values)
+{
+  std::string formatted;
+  for (const auto & kv : values) {
+    if (kv.value.find("\n") != std::string::npos) {
+      // If the value contains a newline, skip it
+      // InfluxDB uses this to separate measurements
+      continue;
+    }
+
+    formatted += escapeSpace(kv.key) + "=";
+
+    if (is_number(kv.value)) {
+      formatted += kv.value;
+    } else {
+      formatted += "\"" + kv.value + "\"";
+    }
+    formatted += ",";
+  }
+  if (!formatted.empty()) {
+    formatted.pop_back();  // Remove the last comma
+  }
+  return formatted;
+}
+
+std::pair<std::string, std::string> splitHardwareID(const std::string & input)
+{
+  size_t first_slash_pos = input.find('/');
+
+  // If no slash is found, treat the entire input as the node_name
+  if (first_slash_pos == std::string::npos) {
+    return {"none", input};
+  }
+
+  size_t second_slash_pos = input.find('/', first_slash_pos + 1);
+
+  // If the second slash is found, extract the "ns" and "node" parts
+  if (second_slash_pos != std::string::npos) {
+    std::string ns = input.substr(first_slash_pos + 1, second_slash_pos - first_slash_pos - 1);
+    std::string node = input.substr(second_slash_pos + 1);
+    return {ns, node};
+  }
+
+  // If no second slash is found, everything after the first slash is the node
+  std::string node = input.substr(first_slash_pos + 1);
+  return {"none", node};    // ns is empty, node is the remaining string
+}
+
+void statusToInfluxLineProtocol(
+  std::string & output,
+  const diagnostic_msgs::msg::DiagnosticStatus & status,
+  const std::string & timestamp_str)
+{
+  // hardware_id is empty for analyzer groups, so skip them
+  if (status.hardware_id.empty()) {
+    return;
+  }
+
+  auto [ns, identifier] = splitHardwareID(status.hardware_id);
+  output += escapeSpace(identifier) + ",ns=" + escapeSpace(ns) +
+    " level=" + std::to_string(status.level) + ",message=\"" + status.message + "\"";
+  auto formatted_key_values = formatValues(status.values);
+  if (!formatted_key_values.empty()) {
+    output += "," + formatted_key_values;
+  }
+  output += " " + timestamp_str + "\n";
+}
+
+std::string diagnosticStatusToInfluxLineProtocol(
+  const diagnostic_msgs::msg::DiagnosticStatus::SharedPtr & msg, const rclcpp::Time & time)
+{
+  std::string output =
+    msg->name + " level=" + std::to_string(msg->level) + " " + toInfluxTimestamp(time) + "\n";
+  return output;
+}
+
+std::string diagnosticArrayToInfluxLineProtocol(
+  const diagnostic_msgs::msg::DiagnosticArray::SharedPtr & diag_msg)
+{
+  std::string output;
+  std::string timestamp = toInfluxTimestamp(diag_msg->header.stamp);
+
+  for (auto & status : diag_msg->status) {
+    statusToInfluxLineProtocol(output, status, timestamp);
+  }
+
+  return output;
+}
+
+#endif  // DIAGNOSTIC_REMOTE_LOGGING__INFLUX_LINE_PROTOCOL_HPP_

--- a/diagnostic_remote_logging/include/diagnostic_remote_logging/influxdb.hpp
+++ b/diagnostic_remote_logging/include/diagnostic_remote_logging/influxdb.hpp
@@ -1,0 +1,71 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, Daan Wijffels
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/**
+ * \author Daan Wijffels
+ */
+
+#ifndef DIAGNOSTIC_REMOTE_LOGGING__INFLUXDB_HPP_
+#define DIAGNOSTIC_REMOTE_LOGGING__INFLUXDB_HPP_
+
+#include <curl/curl.h>
+#include <string>
+
+#include "diagnostic_remote_logging/influx_line_protocol.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+
+class InfluxDB : public rclcpp::Node
+{
+public:
+  explicit InfluxDB(const rclcpp::NodeOptions & opt);
+  ~InfluxDB();
+
+private:
+  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diag_sub_;
+  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr top_level_sub_;
+
+  std::string post_url_, influx_token_;
+  CURL * curl_;
+
+  void setupConnection(const std::string & telegraf_url);
+
+  void diagnosticsCallback(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg);
+  void topLevelCallback(const diagnostic_msgs::msg::DiagnosticStatus::SharedPtr msg);
+
+  bool sendToInfluxDB(const std::string & data);
+};
+
+#endif  // DIAGNOSTIC_REMOTE_LOGGING__INFLUXDB_HPP_

--- a/diagnostic_remote_logging/package.xml
+++ b/diagnostic_remote_logging/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>diagnostic_remote_logging</name>
+  <version>4.3.1</version>
+  <description>diagnostic_remote_logging</description>
+  <maintainer email="dwijffels@lely.com">Daan Wijffels</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>rclcpp_components</build_depend>
+  <build_depend>curl</build_depend>
+  
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/diagnostic_remote_logging/src/influxdb.cpp
+++ b/diagnostic_remote_logging/src/influxdb.cpp
@@ -1,0 +1,173 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, Daan Wijffels
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/**
+ * \author Daan Wijffels
+ */
+
+#include "diagnostic_remote_logging/influxdb.hpp"
+
+InfluxDB::InfluxDB(const rclcpp::NodeOptions & opt)
+: Node("influxdb", opt)
+{
+  post_url_ =
+    this->declare_parameter<std::string>("connection.url", "http://localhost:8086/api/v2/write");
+
+  if (post_url_.empty()) {
+    throw std::runtime_error("Parameter connection.url must be set");
+  }
+
+  std::string organization = declare_parameter("connection.organization", "");
+  std::string bucket = declare_parameter("connection.bucket", "");
+  influx_token_ = declare_parameter("connection.token", "");
+
+  // Check if any of the parameters is set
+  if (!organization.empty() || !bucket.empty() || !influx_token_.empty()) {
+    // Ensure all parameters are set
+    if (organization.empty() || bucket.empty() || influx_token_.empty()) {
+      throw std::runtime_error(
+          "All parameters (connection.organization, connection.bucket, connection.token) "
+          "must be set, or when using a proxy like Telegraf none have to be set.");
+    }
+
+    // Construct the Telegraf URL
+    post_url_ += "?org=" + organization;
+    post_url_ += "&bucket=" + bucket;
+  }
+
+  setupConnection(post_url_);
+
+  if (declare_parameter("send.agg", true)) {
+    diag_sub_ = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+        "/diagnostics_agg", rclcpp::SensorDataQoS(),
+        std::bind(&InfluxDB::diagnosticsCallback, this, std::placeholders::_1));
+  }
+
+  if (declare_parameter<bool>("send.top_level_state", true)) {
+    top_level_sub_ = this->create_subscription<diagnostic_msgs::msg::DiagnosticStatus>(
+        "/diagnostics_toplevel_state", rclcpp::SensorDataQoS(),
+        std::bind(&InfluxDB::topLevelCallback, this, std::placeholders::_1));
+  }
+}
+
+void InfluxDB::diagnosticsCallback(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg)
+{
+  std::string output = diagnosticArrayToInfluxLineProtocol(msg);
+
+  if (!sendToInfluxDB(output)) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to send /diagnostics_agg to telegraf");
+  }
+
+  RCLCPP_DEBUG(this->get_logger(), "%s", output.c_str());
+}
+
+void InfluxDB::topLevelCallback(const diagnostic_msgs::msg::DiagnosticStatus::SharedPtr msg)
+{
+  std::string output = diagnosticStatusToInfluxLineProtocol(msg, this->get_clock()->now());
+
+  if (!sendToInfluxDB(output)) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to send /diagnostics_toplevel_state to telegraf");
+  }
+
+  RCLCPP_DEBUG(this->get_logger(), "%s", output.c_str());
+}
+
+void InfluxDB::setupConnection(const std::string & url)
+{
+  curl_global_init(CURL_GLOBAL_ALL);
+  curl_ = curl_easy_init();
+  if (!curl_) {
+    throw std::runtime_error("Failed to initialize curl");
+  }
+
+  struct curl_slist * headers = nullptr;
+
+  if (!influx_token_.empty()) {
+    headers = curl_slist_append(headers, ("Authorization: Token " + influx_token_).c_str());
+  }
+
+  headers = curl_slist_append(headers, "Content-Type: text/plain; charset=utf-8");
+  headers = curl_slist_append(headers, "Accept: application/json");
+
+  curl_easy_setopt(curl_, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl_, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);  // For keep-alive
+  curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, headers);
+  curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT, 10L);
+  curl_easy_setopt(curl_, CURLOPT_TCP_KEEPALIVE, 1L);
+  curl_easy_setopt(curl_, CURLOPT_POST, 1L);
+}
+
+bool InfluxDB::sendToInfluxDB(const std::string & data)
+{
+  if (!curl_) {
+    RCLCPP_ERROR(this->get_logger(), "cURL not initialized.");
+    return false;
+  }
+
+  curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, data.c_str());
+
+  // Perform the request
+  CURLcode res = curl_easy_perform(curl_);
+
+  // Check for errors
+  if (res != CURLE_OK) {
+    RCLCPP_ERROR(this->get_logger(), "cURL error: %s", curl_easy_strerror(res));
+    return false;
+  }
+  CURLcode response_code;
+  curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &response_code);
+
+  if (response_code != 204) {
+    RCLCPP_ERROR(this->get_logger(), "Error (%d) when sending to telegraf:\n%s", response_code,
+                 data.c_str());
+    return false;
+  }
+
+  return true;
+}
+
+InfluxDB::~InfluxDB()
+{
+  if (curl_) {
+    curl_easy_cleanup(curl_);
+  }
+  curl_global_cleanup();
+}
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(InfluxDB)

--- a/diagnostic_remote_logging/test/influx_line_protocol.cpp
+++ b/diagnostic_remote_logging/test/influx_line_protocol.cpp
@@ -1,0 +1,169 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, Daan Wijffels
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/**
+ * \author Daan Wijffels
+ */
+
+#include "diagnostic_remote_logging/influx_line_protocol.hpp"
+
+#include <gtest/gtest.h>
+
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "diagnostic_msgs/msg/key_value.hpp"
+#include <rclcpp/rclcpp.hpp>
+
+diagnostic_msgs::msg::KeyValue createKeyValue(const std::string & key, const std::string & value)
+{
+  diagnostic_msgs::msg::KeyValue output;
+  output.key = key;
+  output.value = value;
+  return output;
+}
+
+// Test toInfluxTimestamp
+TEST(InfluxTimestampTests, CorrectConversion)
+{
+  rclcpp::Time time(1672531200, 123456789);
+  std::string expected = "1672531200123456789";
+  EXPECT_EQ(toInfluxTimestamp(time), expected);
+}
+
+// Test escapeSpace
+TEST(EscapeSpaceTests, HandlesSpaces)
+{
+  EXPECT_EQ(escapeSpace("test string"), "test\\ string");
+  EXPECT_EQ(escapeSpace("no_space"), "no_space");
+  EXPECT_EQ(escapeSpace("multiple spaces here"), "multiple\\ spaces\\ here");
+}
+
+// Test is_number
+TEST(IsNumberTests, ValidatesNumbers)
+{
+  EXPECT_TRUE(is_number("123"));
+  EXPECT_TRUE(is_number("123.456"));
+  EXPECT_TRUE(is_number("-123.456"));
+  EXPECT_FALSE(is_number("123abc"));
+  EXPECT_FALSE(is_number("abc123"));
+  EXPECT_FALSE(is_number(""));
+}
+
+// Test formatValues
+TEST(FormatValuesTests, FormatsKeyValuePairs)
+{
+  std::vector<diagnostic_msgs::msg::KeyValue> values;
+  values.push_back(createKeyValue("key1", "value"));
+  values.push_back(createKeyValue("key2", "42"));
+  values.push_back(createKeyValue("key3", "-3.14"));
+  values.push_back(createKeyValue("key with spaces", "value with spaces"));
+
+  std::string expected =
+    "key1=\"value\",key2=42,key3=-3.14,key\\ with\\ "
+    "spaces=\"value with spaces\"";
+  EXPECT_EQ(formatValues(values), expected);
+}
+
+// Test splitHardwareID
+TEST(SplitHardwareIDTests, SplitsCorrectly)
+{
+  EXPECT_EQ(splitHardwareID("node_name"), std::make_pair(std::string("none"), std::string("node_"
+                                                                                          "name")));
+  EXPECT_EQ(splitHardwareID("/ns/node_name"), std::make_pair(std::string("ns"), std::string("node_"
+                                                                                            "nam"
+                                                                                            "e")));
+  EXPECT_EQ(splitHardwareID("/ns/prefix/node_name"),
+            std::make_pair(std::string("ns"), std::string("prefix/"
+                                                          "node_name")));
+}
+
+// Test statusToInfluxLineProtocol
+TEST(StatusToInfluxLineProtocolTests, FormatsCorrectly)
+{
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  status.hardware_id = "/ns/node_name";
+  status.level = 2;
+  status.message = "Test message";
+  status.values.push_back(createKeyValue("key1", "value1"));
+  status.values.push_back(createKeyValue("key2", "42"));
+
+  std::string expected =
+    "node_name,ns=ns level=2,message=\"Test message\",key1=\"value1\",key2=42"
+    " 1672531200123456789\n";
+  std::string output;
+  statusToInfluxLineProtocol(output, status, "1672531200123456789");
+
+  EXPECT_EQ(output, expected);
+}
+
+// Test diagnosticArrayToInfluxLineProtocol
+TEST(DiagnosticArrayToInfluxLineProtocolTests, HandlesMultipleStatuses)
+{
+  auto diag_msg = std::make_shared<diagnostic_msgs::msg::DiagnosticArray>();
+  diag_msg->header.stamp = rclcpp::Time(1672531200, 123456789);
+
+  diagnostic_msgs::msg::DiagnosticStatus status1;
+  status1.hardware_id = "/ns1/node1";
+  status1.level = 1;
+  status1.message = "First status";
+  status1.values.push_back(createKeyValue("keyA", "valueA"));
+
+  diagnostic_msgs::msg::DiagnosticStatus status2;
+  status2.hardware_id = "node2";
+  status2.level = 2;
+  status2.message = "Second status";
+  status2.values.push_back(createKeyValue("keyB", "42"));
+
+  diag_msg->status = {status1, status2};
+
+  std::string expected =
+    "node1,ns=ns1 level=1,message=\"First "
+    "status\",keyA=\"valueA\" 1672531200123456789\n"
+    "node2,ns=none level=2,message=\"Second "
+    "status\",keyB=42 1672531200123456789\n";
+
+  EXPECT_EQ(diagnosticArrayToInfluxLineProtocol(diag_msg), expected);
+}
+
+// Test diagnosticStatusToInfluxLineProtocol
+TEST(DiagnosticStatusToInfluxLineProtocol, HandlesSingleStatus)
+{
+  auto status = std::make_shared<diagnostic_msgs::msg::DiagnosticStatus>();
+  status->level = 1;
+  status->name = "toplevel_state";
+  auto time = rclcpp::Time(1672531200, 123456789);
+
+  std::string expected = "toplevel_state level=1 1672531200123456789\n";
+  EXPECT_EQ(diagnosticStatusToInfluxLineProtocol(status, time), expected);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-jazzy`:
 - [Grafana Integration (#425)](https://github.com/ros/diagnostics/pull/425)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)