### PR TITLE
[ros2-jazzy] Don't use `match` (#442)

### DIFF
--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/hd_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/hd_monitor.py
@@ -101,15 +101,14 @@ class HDMonitor(Node):
         see the class documentation for declared parameters.
         """
         for param in params:
-            match param.name:
-                case 'path':
-                    self._path = str(
-                        Path(param.value).expanduser().resolve(strict=True)
-                    )
-                case 'free_percent_low':
-                    self._free_percent_low = param.value
-                case 'free_percent_crit':
-                    self._free_percent_crit = param.value
+            if param.name == 'path':
+                self._path = str(
+                    Path(param.value).expanduser().resolve(strict=True)
+                )
+            elif param.name == 'free_percent_low':
+                self._free_percent_low = param.value
+            elif param.name == 'free_percent_crit':
+                self._free_percent_crit = param.value
 
         return SetParametersResult(successful=True)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2-humble` to `ros2-jazzy`:
 - [Don&#x27;t use &#x60;match&#x60; (#442)](https://github.com/ros/diagnostics/pull/442)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)