### PR TITLE
[ros2-humble] Fix reported hd_monitor available value (#443)

### DIFF
--- a/diagnostic_common_diagnostics/README.md
+++ b/diagnostic_common_diagnostics/README.md
@@ -67,7 +67,7 @@ Computer name in diagnostics output (ex: 'c1')
 Disable self test.
 
 ## hd_monitor.py
-Runs 'shutil.disk_usage' to check if there is enough space left on a given device.
+Runs 'shutil.disk_usage' to check if there is enough space left on a given device. With default parameters, the following thresholds are used:
 * Above 5% of free space left, an `OK` status will be published.
 * Between 5% and 1%, a `WARN` status will be published,
 * Below 1%, an `ERROR` status will be published.
@@ -81,6 +81,14 @@ The diagnostics information.
 #### path
 (default: home directory "~")
 Path in which to check remaining space.
+
+#### free_percent_low
+(default: 5%)
+Warning threshold.
+
+#### free_percent_crit
+(default: 1%)
+Error threshold.
 
 ## ram_monitor.py
 The `ram_monitor` module allows users to monitor the RAM usage of their system in real-time.

--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/hd_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/hd_monitor.py
@@ -44,13 +44,13 @@ from typing import List
 
 from diagnostic_msgs.msg import DiagnosticStatus, KeyValue
 from diagnostic_updater import Updater
-from rcl_interfaces.msg import SetParametersResult
+from rcl_interfaces.msg import ParameterDescriptor, SetParametersResult
 import rclpy
 from rclpy.node import Node
 
 
-FREE_PERCENT_LOW = 0.05
-FREE_PERCENT_CRIT = 0.01
+FREE_PERCENT_LOW = 5
+FREE_PERCENT_CRIT = 1
 DICT_STATUS = {
     DiagnosticStatus.OK: 'OK',
     DiagnosticStatus.WARN: 'Warning',
@@ -82,13 +82,18 @@ class HDMonitor(Node):
         super().__init__(f'hd_monitor_{cleaned_hostname}')
 
         self._path = '~'
-        self._free_percent_low = 0.05
-        self._free_percent_crit = 0.01
+        self._free_percent_low = FREE_PERCENT_LOW
+        self._free_percent_crit = FREE_PERCENT_CRIT
 
         self.add_on_set_parameters_callback(self.callback_config)
-        self.declare_parameter('path', self._path)
-        self.declare_parameter('free_percent_low', self._free_percent_low)
-        self.declare_parameter('free_percent_crit', self._free_percent_crit)
+        self.declare_parameter('path', self._path,  ParameterDescriptor(
+            description='Path in which to check remaining space.'))
+        self.declare_parameter(
+            'free_percent_low', self._free_percent_low,  ParameterDescriptor(
+                description='Warning threshold.', type=int()))
+        self.declare_parameter(
+            'free_percent_crit', self._free_percent_crit,  ParameterDescriptor(
+                description='Error threshold.', type=int()))
 
         self._updater = Updater(self)
         self._updater.setHardwareID(hostname)
@@ -121,7 +126,7 @@ class HDMonitor(Node):
         diag.level = DiagnosticStatus.OK
 
         total, _, free = disk_usage(self._path)
-        percent = free / total
+        percent = free / total * 100.0
 
         if percent > self._free_percent_low:
             diag.level = DiagnosticStatus.OK
@@ -136,7 +141,7 @@ class HDMonitor(Node):
                 KeyValue(key='Name', value=self._path),
                 KeyValue(key='Status', value=DICT_STATUS[diag.level]),
                 KeyValue(key='Total (Go)', value=str(total_go)),
-                KeyValue(key='Available (%)', value=str(round(percent, 2))),
+                KeyValue(key='Available (%)', value=str(round(percent, 1))),
             ]
         )
 

--- a/diagnostic_common_diagnostics/test/systemtest/test_hd_monitor_launchtest.py
+++ b/diagnostic_common_diagnostics/test/systemtest/test_hd_monitor_launchtest.py
@@ -59,7 +59,7 @@ def generate_test_description():
                 executable='hd_monitor.py',
                 name='hd_monitor',
                 output='screen',
-                parameters=[{'free_percent_low': 0.20, 'free_percent_crit': 0.05}],
+                parameters=[{'free_percent_low': 10, 'free_percent_crit': 5}],
             ),
             launch_testing.actions.ReadyToTest(),
         ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-humble`:
 - [Fix reported hd_monitor available value (#443)](https://github.com/ros/diagnostics/pull/443)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)