### PR TITLE
Propagate clock instead of creating default

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/analyzer.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/analyzer.hpp
@@ -94,8 +94,7 @@ public:
   /*!
    *\brief Default constructor, called by pluginlib.
    */
-  Analyzer()
-  : clock_(std::make_shared<rclcpp::Clock>()) {}
+  Analyzer() {}
 
   virtual ~Analyzer() {}
 

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer.hpp
@@ -229,6 +229,7 @@ public:
   virtual bool match(const std::string & name);
 
 private:
+  rclcpp::Node::SharedPtr node_;
   std::vector<std::string> chaff_; /**< Removed from the start of node names. */
   std::vector<std::string> expected_;
   std::vector<std::string> startswith_;

--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.hpp
@@ -101,7 +101,8 @@ public:
    * Must be initialized in order to prepend the path to all outgoing status messages.
    */
   bool init(
-    const std::string & path, const std::string & breadcrumb, double timeout = -1.0,
+    const std::string & path, const std::string & breadcrumb,
+    const rclcpp::Node::SharedPtr node, double timeout = -1.0,
     int num_items_expected = -1, bool discard_stale = false)
   {
     num_items_expected_ = num_items_expected;
@@ -109,6 +110,7 @@ public:
     path_ = path + "/" + nice_name_;
     discard_stale_ = discard_stale;
     breadcrumb_ = breadcrumb;
+    clock_ = node->get_clock();
 
     if (discard_stale_ && timeout <= 0) {
       RCLCPP_WARN(

--- a/diagnostic_aggregator/include/diagnostic_aggregator/other_analyzer.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/other_analyzer.hpp
@@ -85,34 +85,15 @@ public:
    *\param path Base path of Aggregator
    *\param breadcrumb Prefix for parameter getter.
    */
-  bool init(const std::string & path, const std::string & breadcrumb = "")
+  bool init(
+    const std::string & path, const std::string & breadcrumb,
+    const rclcpp::Node::SharedPtr node)
   {
     (void)breadcrumb;
 
     nice_name_ = "Other";
     path_ = path;
-    return GenericAnalyzerBase::init(path_, "", 5.0, -1, true);
-  }
-
-  /*
-   *\brief OtherAnalyzer cannot be initialized with a NodeHandle
-   *
-   *\return False, since NodeHandle initialization isn't valid
-   */
-  bool init(
-    const std::string & base_path, const std::string & breadcrumb,
-    const rclcpp::Node::SharedPtr node)
-  {
-    (void)base_path;
-    (void)breadcrumb;
-    (void)node;
-
-    RCLCPP_ERROR(
-      rclcpp::get_logger(
-        "generic_analyzer_base"),
-      R"(OtherAnalyzer was attempted to initialize with a NodeHandle.
-      This analyzer cannot be used as a plugin.)");
-    return false;
+    return GenericAnalyzerBase::init(path_, "", node, 5.0, -1, true);
   }
 
   /*

--- a/diagnostic_aggregator/include/diagnostic_aggregator/status_item.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/status_item.hpp
@@ -187,13 +187,16 @@ public:
    *\brief Constructed from const DiagnosticStatus*
    */
   DIAGNOSTIC_AGGREGATOR_PUBLIC
-  explicit StatusItem(const diagnostic_msgs::msg::DiagnosticStatus * status);
+  StatusItem(
+    const diagnostic_msgs::msg::DiagnosticStatus * status,
+    rclcpp::Clock::SharedPtr clock);
 
   /*!
   *\brief Constructed from string of item name
   */
   DIAGNOSTIC_AGGREGATOR_PUBLIC
   StatusItem(
+    rclcpp::Clock::SharedPtr clock,
     const std::string item_name, const std::string message = "Missing",
     const DiagnosticLevel level = Level_Stale);
 

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -83,8 +83,8 @@ Aggregator::Aggregator(rclcpp::NodeOptions options)
     n_->create_publisher<DiagnosticStatus>("/diagnostics_toplevel_state", 1);
 
   int publish_rate_ms = 1000 / pub_rate_;
-  publish_timer_ = n_->create_wall_timer(
-    std::chrono::milliseconds(publish_rate_ms),
+  publish_timer_ = rclcpp::create_timer(
+    n_, clock_, std::chrono::milliseconds(publish_rate_ms),
     std::bind(&Aggregator::publishData, this));
 
   param_sub_ = n_->create_subscription<rcl_interfaces::msg::ParameterEvent>(
@@ -144,7 +144,7 @@ void Aggregator::initAnalyzers()
 
     // Last analyzer handles remaining data
     other_analyzer_ = std::make_unique<OtherAnalyzer>(other_as_errors);
-    other_analyzer_->init(base_path_);  // This always returns true
+    other_analyzer_->init(base_path_, "", n_);  // This always returns true
   }
 }
 
@@ -181,7 +181,7 @@ void Aggregator::diagCallback(const DiagnosticArray::SharedPtr diag_msg)
     std::lock_guard<std::mutex> lock(mutex_);
     for (auto j = 0u; j < diag_msg->status.size(); ++j) {
       analyzed = false;
-      auto item = std::make_shared<StatusItem>(&diag_msg->status[j]);
+      auto item = std::make_shared<StatusItem>(&diag_msg->status[j], n_->get_clock());
 
       if (analyzer_group_->match(item->getName())) {
         analyzed = analyzer_group_->analyze(item);

--- a/diagnostic_aggregator/src/analyzer_group.cpp
+++ b/diagnostic_aggregator/src/analyzer_group.cpp
@@ -66,6 +66,7 @@ bool AnalyzerGroup::init(
   path_ = path;
   breadcrumb_ = breadcrumb;
   nice_name_ = path;
+  clock_ = n->get_clock();
 
   std::map<std::string, rclcpp::Parameter> parameters;
   if (!n->get_parameters(breadcrumb_, parameters)) {
@@ -128,7 +129,7 @@ bool AnalyzerGroup::init(
         RCLCPP_ERROR(
           logger_, "Failed to load analyzer %s, type %s. Caught exception: %s", ns.c_str(),
           an_type.c_str(), e.what());
-        auto item = std::make_shared<StatusItem>(ns, "Pluginlib exception loading analyzer");
+        auto item = std::make_shared<StatusItem>(n->get_clock(), ns, "Pluginlib exception loading analyzer");
         aux_items_.push_back(item);
         init_ok = false;
         continue;
@@ -139,7 +140,7 @@ bool AnalyzerGroup::init(
           logger_, "Pluginlib returned a null analyzer for %s, namespace %s.", an_type.c_str(),
           n->get_namespace());
         std::shared_ptr<StatusItem> item(
-          new StatusItem(ns, "Pluginlib return NULL Analyzer for " + an_type));
+          new StatusItem(n->get_clock(), ns, "Pluginlib return NULL Analyzer for " + an_type));
         aux_items_.push_back(item);
         init_ok = false;
         continue;
@@ -158,7 +159,7 @@ bool AnalyzerGroup::init(
         RCLCPP_ERROR(
           logger_, "Unable to initialize analyzer NS: %s, type: %s", n->get_namespace(),
           an_type.c_str());
-        std::shared_ptr<StatusItem> item(new StatusItem(ns, "Analyzer init failed"));
+        std::shared_ptr<StatusItem> item(new StatusItem(n->get_clock(), ns, "Analyzer init failed"));
         aux_items_.push_back(item);
         init_ok = false;
         continue;

--- a/diagnostic_aggregator/src/analyzer_group.cpp
+++ b/diagnostic_aggregator/src/analyzer_group.cpp
@@ -129,7 +129,8 @@ bool AnalyzerGroup::init(
         RCLCPP_ERROR(
           logger_, "Failed to load analyzer %s, type %s. Caught exception: %s", ns.c_str(),
           an_type.c_str(), e.what());
-        auto item = std::make_shared<StatusItem>(n->get_clock(), ns, "Pluginlib exception loading analyzer");
+        auto item = std::make_shared<StatusItem>(
+          n->get_clock(), ns, "Pluginlib exception loading analyzer");
         aux_items_.push_back(item);
         init_ok = false;
         continue;
@@ -159,7 +160,8 @@ bool AnalyzerGroup::init(
         RCLCPP_ERROR(
           logger_, "Unable to initialize analyzer NS: %s, type: %s", n->get_namespace(),
           an_type.c_str());
-        std::shared_ptr<StatusItem> item(new StatusItem(n->get_clock(), ns, "Analyzer init failed"));
+        std::shared_ptr<StatusItem> item(
+          new StatusItem(n->get_clock(), ns, "Analyzer init failed"));
         aux_items_.push_back(item);
         init_ok = false;
         continue;

--- a/diagnostic_aggregator/src/generic_analyzer.cpp
+++ b/diagnostic_aggregator/src/generic_analyzer.cpp
@@ -56,9 +56,11 @@ GenericAnalyzer::GenericAnalyzer() {}
 bool GenericAnalyzer::init(
   const std::string & path, const std::string & breadcrumb, const rclcpp::Node::SharedPtr n)
 {
+  node_ = n;
   path_ = path;
   breadcrumb_ = breadcrumb;
   nice_name_ = breadcrumb;
+  clock_ = n->get_clock();
   RCLCPP_DEBUG(
     rclcpp::get_logger("GenericAnalyzer"), "GenericAnalyzer, breadcrumb: %s", breadcrumb_.c_str());
 
@@ -114,7 +116,7 @@ bool GenericAnalyzer::init(
         rclcpp::get_logger("GenericAnalyzer"), "GenericAnalyzer '%s' found expected: %s",
         nice_name_.c_str(), pvalue.value_to_string().c_str());
       for (auto exp : pvalue.as_string_array()) {
-        auto item = std::make_shared<StatusItem>(exp);
+        auto item = std::make_shared<StatusItem>(n->get_clock(), exp);
         this->addItem(exp, item);
       }
     } else if (pname.compare("regex") == 0) {
@@ -178,7 +180,7 @@ bool GenericAnalyzer::init(
     my_path = "/" + my_path;
   }
 
-  return GenericAnalyzerBase::init(path_, breadcrumb_, timeout, num_items_expected, discard_stale);
+  return GenericAnalyzerBase::init(path_, breadcrumb_, node_, timeout, num_items_expected, discard_stale);
 }
 
 GenericAnalyzer::~GenericAnalyzer() {}
@@ -282,7 +284,7 @@ vector<std::shared_ptr<diagnostic_msgs::msg::DiagnosticStatus>> GenericAnalyzer:
 
   // Add missing names to header ...
   for (unsigned int i = 0; i < expected_names_missing.size(); ++i) {
-    std::shared_ptr<StatusItem> item(new StatusItem(expected_names_missing[i]));
+    std::shared_ptr<StatusItem> item(new StatusItem(node_->get_clock(), expected_names_missing[i]));
     processed.push_back(item->toStatusMsg(path_, true));
   }
 

--- a/diagnostic_aggregator/src/generic_analyzer.cpp
+++ b/diagnostic_aggregator/src/generic_analyzer.cpp
@@ -180,7 +180,8 @@ bool GenericAnalyzer::init(
     my_path = "/" + my_path;
   }
 
-  return GenericAnalyzerBase::init(path_, breadcrumb_, node_, timeout, num_items_expected, discard_stale);
+  return GenericAnalyzerBase::init(
+    path_, breadcrumb_, node_, timeout, num_items_expected, discard_stale);
 }
 
 GenericAnalyzer::~GenericAnalyzer() {}

--- a/diagnostic_aggregator/src/status_item.cpp
+++ b/diagnostic_aggregator/src/status_item.cpp
@@ -45,8 +45,10 @@ using std::string;
 
 using rclcpp::get_logger;
 
-StatusItem::StatusItem(const diagnostic_msgs::msg::DiagnosticStatus * status)
-: clock_(new rclcpp::Clock())
+StatusItem::StatusItem(
+  const diagnostic_msgs::msg::DiagnosticStatus * status,
+  rclcpp::Clock::SharedPtr clock)
+: clock_(clock)
 {
   level_ = valToLevel(status->level);
   name_ = status->name;
@@ -59,8 +61,12 @@ StatusItem::StatusItem(const diagnostic_msgs::msg::DiagnosticStatus * status)
   update_time_ = clock_->now();
 }
 
-StatusItem::StatusItem(const string item_name, const string message, const DiagnosticLevel level)
-: clock_(new rclcpp::Clock())
+StatusItem::StatusItem(
+  rclcpp::Clock::SharedPtr clock,
+  const string item_name,
+  const string message,
+  const DiagnosticLevel level)
+: clock_(clock)
 {
   RCLCPP_DEBUG(rclcpp::get_logger("StatusItem"), "StatusItem constructor from string");
   name_ = item_name;


### PR DESCRIPTION
We were having trouble with diagnostics being stale in simulation when the real time factor is low. I noticed that the analyzers are creating new clocks (that use by default system time), instead of propagating down the clock of the main node (that uses the correct time in both simulation and real life).

I couldn't find any issues about this, so I implemented a fix.