### PR TITLE
[ros2-jazzy] Fix: Merge messages if all level 0 in C++ (matching python) (#436)

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_status_wrapper.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_status_wrapper.hpp
@@ -116,7 +116,7 @@ public:
 
   void mergeSummary(unsigned char lvl, const std::string s)
   {
-    if ((lvl > 0) && (level > 0)) {
+    if ((lvl > 0) == (level > 0)) {
       if (!message.empty()) {
         message += "; ";
         message += s;

--- a/diagnostic_updater/test/diagnostic_status_wrapper_test.cpp
+++ b/diagnostic_updater/test/diagnostic_status_wrapper_test.cpp
@@ -86,7 +86,7 @@ TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperMergeSummary) {
 
   dsw.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Still ok");
   EXPECT_EQ(dsw.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
-  EXPECT_EQ(dsw.message, "Was ok");
+  EXPECT_EQ(dsw.message, "Was ok; Still ok");
   EXPECT_EQ(dsw.values.size(), 0u);
 
   dsw.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Warning");

--- a/diagnostic_updater/test/diagnostic_updater_test.cpp
+++ b/diagnostic_updater/test/diagnostic_updater_test.cpp
@@ -219,7 +219,7 @@ TEST(DiagnosticUpdater, testDiagnosticStatusWrapperMergeSummary) {
   stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::OK, "New");
   EXPECT_EQ(diagnostic_msgs::msg::DiagnosticStatus::OK, stat.level) <<
     "Bad level, merging levels (OK,OK)";
-  EXPECT_STREQ("Old", stat.message.c_str()) <<
+  EXPECT_STREQ("Old; New", stat.message.c_str()) <<
     "Bad summary, merging levels (OK,OK)";
 
   stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Old");


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-jazzy`:
 - [Fix: Merge messages if all level 0 in C++ (matching python) (#436)](https://github.com/ros/diagnostics/pull/436)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)