### PR TITLE
Declaring ament_cmake_ros as buildtool_depend

### DIFF
--- a/diagnostic_updater/package.xml
+++ b/diagnostic_updater/package.xml
@@ -20,7 +20,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
-
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclpy</depend>


### PR DESCRIPTION
Fixes #457 