### PR TITLE
[ros2-jazzy] Declaring ament_cmake_ros as buildtool_depend (#462)

### DIFF
--- a/diagnostic_updater/package.xml
+++ b/diagnostic_updater/package.xml
@@ -20,7 +20,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
-
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclpy</depend>


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-jazzy`:
 - [Declaring ament_cmake_ros as buildtool_depend (#462)](https://github.com/ros/diagnostics/pull/462)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)