### PR TITLE
fix: publish diagnostic_agg using a timer, not wall_timer

### DIFF
--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -83,7 +83,7 @@ Aggregator::Aggregator(rclcpp::NodeOptions options)
     n_->create_publisher<DiagnosticStatus>("/diagnostics_toplevel_state", 1);
 
   int publish_rate_ms = 1000 / pub_rate_;
-  publish_timer_ = n_->create_wall_timer(
+  publish_timer_ = n_->create_timer(
     std::chrono::milliseconds(publish_rate_ms),
     std::bind(&Aggregator::publishData, this));
 


### PR DESCRIPTION
Similar to https://github.com/ros/diagnostics/pull/458

diagnostics_agg should be published using a `timer` rather than `wall_timer` so it respects `use_sim_time`