### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -55,8 +55,6 @@ target_link_libraries(${ANALYZERS} PUBLIC
   "pluginlib"
   "rclcpp"
   "std_msgs"
-)
-target_link_libraries(${ANALYZERS}
   ${PROJECT_NAME})
 target_compile_definitions(${ANALYZERS}
   PRIVATE "DIAGNOSTIC_AGGREGATOR_BUILDING_DLL")

--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   "diagnostic_msgs"
   "pluginlib"
   "rclcpp"
@@ -50,7 +50,7 @@ add_library(${ANALYZERS} SHARED
 target_include_directories(${ANALYZERS} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(${ANALYZERS}
+target_link_libraries(${ANALYZERS} PUBLIC
   "diagnostic_msgs"
   "pluginlib"
   "rclcpp"
@@ -71,7 +71,7 @@ target_link_libraries(aggregator_node
 
 # Add analyzer
 add_executable(add_analyzer src/add_analyzer.cpp)
-ament_target_dependencies(add_analyzer rclcpp rcl_interfaces)
+target_link_libraries(add_analyzer PUBLIC rclcpp rcl_interfaces)
 
 # Testing macro
 if(BUILD_TESTING)

--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -26,10 +26,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  "diagnostic_msgs"
-  "pluginlib"
-  "rclcpp"
-  "std_msgs"
+  ${diagnostic_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  pluginlib::pluginlib
+  rclcpp::rclcpp
 )
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE "DIAGNOSTIC_AGGREGATOR_BUILDING_DLL")
@@ -51,11 +51,11 @@ target_include_directories(${ANALYZERS} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(${ANALYZERS} PUBLIC
-  "diagnostic_msgs"
-  "pluginlib"
-  "rclcpp"
-  "std_msgs"
-  ${PROJECT_NAME})
+  ${PROJECT_NAME}
+  ${diagnostic_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  rclcpp::rclcpp
+)
 target_compile_definitions(${ANALYZERS}
   PRIVATE "DIAGNOSTIC_AGGREGATOR_BUILDING_DLL")
 
@@ -69,7 +69,7 @@ target_link_libraries(aggregator_node
 
 # Add analyzer
 add_executable(add_analyzer src/add_analyzer.cpp)
-target_link_libraries(add_analyzer PUBLIC rclcpp rcl_interfaces)
+target_link_libraries(add_analyzer PUBLIC ${rcl_interfaces_TARGETS} rclcpp::rclcpp)
 
 # Testing macro
 if(BUILD_TESTING)

--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -52,6 +52,7 @@ target_include_directories(${ANALYZERS} PUBLIC
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(${ANALYZERS} PUBLIC
   ${PROJECT_NAME}
+  pluginlib::pluginlib
   ${diagnostic_msgs_TARGETS}
   ${std_msgs_TARGETS}
   rclcpp::rclcpp

--- a/diagnostic_remote_logging/CMakeLists.txt
+++ b/diagnostic_remote_logging/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(
 )
 add_library(influx_component SHARED src/influxdb.cpp)
 
-ament_target_dependencies(influx_component ${dependencies})
+target_link_libraries(influx_component PUBLIC ${dependencies})
 
 ament_export_dependencies(influx_component ${dependencies})
 

--- a/diagnostic_remote_logging/CMakeLists.txt
+++ b/diagnostic_remote_logging/CMakeLists.txt
@@ -23,7 +23,11 @@ include_directories(
 )
 add_library(influx_component SHARED src/influxdb.cpp)
 
-target_link_libraries(influx_component PUBLIC ${dependencies})
+target_link_libraries(influx_component PUBLIC
+    ${diagnostic_msgs_TARGETS}
+    rclcpp::rclcpp
+    rclcpp_components::component
+)
 
 ament_export_dependencies(influx_component ${dependencies})
 

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -31,8 +31,8 @@ target_include_directories(
 target_link_libraries(
   ${PROJECT_NAME}
   PUBLIC
-  diagnostic_msgs
-  rclcpp
+  ${diagnostic_msgs_TARGETS}
+  rclcpp::rclcpp
 )
 
 install(
@@ -47,10 +47,10 @@ install(
 add_executable(example src/example.cpp)
 target_link_libraries(example
   PUBLIC
-  "diagnostic_msgs"
-  "rclcpp"
-  "std_msgs"
   ${PROJECT_NAME}
+  ${diagnostic_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  rclcpp::rclcpp
 )
 
 if(BUILD_TESTING)

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -50,8 +50,8 @@ target_link_libraries(example
   "diagnostic_msgs"
   "rclcpp"
   "std_msgs"
+  ${PROJECT_NAME}
 )
-target_link_libraries(example ${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(
+target_link_libraries(
   ${PROJECT_NAME}
   PUBLIC
   diagnostic_msgs
@@ -45,8 +45,8 @@ install(
 )
 
 add_executable(example src/example.cpp)
-ament_target_dependencies(
-  example
+target_link_libraries(example
+  PUBLIC
   "diagnostic_msgs"
   "rclcpp"
   "std_msgs"

--- a/self_test/CMakeLists.txt
+++ b/self_test/CMakeLists.txt
@@ -38,8 +38,8 @@ target_include_directories(run_selftest
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(
-  run_selftest
+target_link_libraries(run_selftest
+  PUBLIC
   "builtin_interfaces"
   "diagnostic_msgs"
   "diagnostic_updater"
@@ -53,8 +53,8 @@ target_include_directories(selftest_example
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(
-  selftest_example
+target_link_libraries(selftest_example
+  PUBLIC
   "builtin_interfaces"
   "diagnostic_msgs"
   "diagnostic_updater"

--- a/self_test/CMakeLists.txt
+++ b/self_test/CMakeLists.txt
@@ -40,11 +40,11 @@ target_include_directories(run_selftest
 )
 target_link_libraries(run_selftest
   PUBLIC
-  "builtin_interfaces"
-  "diagnostic_msgs"
-  "diagnostic_updater"
-  "rclcpp"
-  "rcutils"
+  ${builtin_interfaces_TARGETS}
+  ${diagnostic_msgs_TARGETS}
+  diagnostic_updater::diagnostic_updater
+  rclcpp::rclcpp
+  rcutils::rcutils
 )
 
 add_executable(selftest_example example/selftest_example.cpp)
@@ -55,11 +55,11 @@ target_include_directories(selftest_example
 )
 target_link_libraries(selftest_example
   PUBLIC
-  "builtin_interfaces"
-  "diagnostic_msgs"
-  "diagnostic_updater"
-  "rclcpp"
-  "rcutils"
+  ${builtin_interfaces_TARGETS}
+  ${diagnostic_msgs_TARGETS}
+  diagnostic_updater::diagnostic_updater
+  rclcpp::rclcpp
+  rcutils::rcutils
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
