### PR TITLE
[ros2-kilted] Kilted dep fix (#474)

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -25,11 +25,11 @@ add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(${PROJECT_NAME}
-  "diagnostic_msgs"
-  "pluginlib"
-  "rclcpp"
-  "std_msgs"
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${diagnostic_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  pluginlib::pluginlib
+  rclcpp::rclcpp
 )
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE "DIAGNOSTIC_AGGREGATOR_BUILDING_DLL")
@@ -50,14 +50,13 @@ add_library(${ANALYZERS} SHARED
 target_include_directories(${ANALYZERS} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(${ANALYZERS}
-  "diagnostic_msgs"
-  "pluginlib"
-  "rclcpp"
-  "std_msgs"
+target_link_libraries(${ANALYZERS} PUBLIC
+  ${PROJECT_NAME}
+  ${diagnostic_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  pluginlib::pluginlib
+  rclcpp::rclcpp
 )
-target_link_libraries(${ANALYZERS}
-  ${PROJECT_NAME})
 target_compile_definitions(${ANALYZERS}
   PRIVATE "DIAGNOSTIC_AGGREGATOR_BUILDING_DLL")
 
@@ -71,7 +70,7 @@ target_link_libraries(aggregator_node
 
 # Add analyzer
 add_executable(add_analyzer src/add_analyzer.cpp)
-ament_target_dependencies(add_analyzer rclcpp rcl_interfaces)
+target_link_libraries(add_analyzer PUBLIC ${rcl_interfaces_TARGETS} rclcpp::rclcpp)
 
 # Testing macro
 if(BUILD_TESTING)

--- a/diagnostic_remote_logging/CMakeLists.txt
+++ b/diagnostic_remote_logging/CMakeLists.txt
@@ -23,7 +23,11 @@ include_directories(
 )
 add_library(influx_component SHARED src/influxdb.cpp)
 
-ament_target_dependencies(influx_component ${dependencies})
+target_link_libraries(influx_component PUBLIC
+    ${diagnostic_msgs_TARGETS}
+    rclcpp::rclcpp
+    rclcpp_components::component
+)
 
 ament_export_dependencies(influx_component ${dependencies})
 

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -28,11 +28,11 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(
+target_link_libraries(
   ${PROJECT_NAME}
   PUBLIC
-  diagnostic_msgs
-  rclcpp
+  ${diagnostic_msgs_TARGETS}
+  rclcpp::rclcpp
 )
 
 install(
@@ -45,13 +45,13 @@ install(
 )
 
 add_executable(example src/example.cpp)
-ament_target_dependencies(
-  example
-  "diagnostic_msgs"
-  "rclcpp"
-  "std_msgs"
+target_link_libraries(example
+  PUBLIC
+  ${PROJECT_NAME}
+  ${diagnostic_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  rclcpp::rclcpp
 )
-target_link_libraries(example ${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/self_test/CMakeLists.txt
+++ b/self_test/CMakeLists.txt
@@ -38,13 +38,13 @@ target_include_directories(run_selftest
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(
-  run_selftest
-  "builtin_interfaces"
-  "diagnostic_msgs"
-  "diagnostic_updater"
-  "rclcpp"
-  "rcutils"
+target_link_libraries(run_selftest
+  PUBLIC
+  ${builtin_interfaces_TARGETS}
+  ${diagnostic_msgs_TARGETS}
+  diagnostic_updater::diagnostic_updater
+  rclcpp::rclcpp
+  rcutils::rcutils
 )
 
 add_executable(selftest_example example/selftest_example.cpp)
@@ -53,13 +53,13 @@ target_include_directories(selftest_example
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(
-  selftest_example
-  "builtin_interfaces"
-  "diagnostic_msgs"
-  "diagnostic_updater"
-  "rclcpp"
-  "rcutils"
+target_link_libraries(selftest_example
+  PUBLIC
+  ${builtin_interfaces_TARGETS}
+  ${diagnostic_msgs_TARGETS}
+  diagnostic_updater::diagnostic_updater
+  rclcpp::rclcpp
+  rcutils::rcutils
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-kilted`:
 - [Kilted dep fix (#474)](https://github.com/ros/diagnostics/pull/474)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)