### PR TITLE
[ros2-jazzy] Add mergify rules (#477)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: add ros2 label
+    description: If targeting an ROS2 branch, add the label
+    conditions:
+      - base=ros2
+    actions:
+      label:
+        add:
+          - ros2


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-jazzy`:
 - [Add mergify rules (#477)](https://github.com/ros/diagnostics/pull/477)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)