### PR TITLE
[ros2-jazzy] Another mergify rule (#478)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,8 +2,19 @@ pull_request_rules:
   - name: add ros2 label
     description: If targeting an ROS2 branch, add the label
     conditions:
-      - base=ros2
+      - base = ros2
     actions:
       label:
         add:
           - ros2
+  - name: no PRs against distro-specific branches
+    description: PRs against branches like ros-humble are closed automatically. Unless they are a backport.
+    conditions:
+      - and:
+        - base ~= ^ros2-[a-z]+$
+        - not:
+            head ~= ^backport\/.+$
+    actions:
+      close: 
+        message: Please make all PRs against the `ros2` branch. They will be backported if possible.
+      


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-jazzy`:
 - [Another mergify rule (#478)](https://github.com/ros/diagnostics/pull/478)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)