### PR TITLE
[ros2-jazzy] Automerge (#480)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,14 @@
+{
+    "repoName": "diagnostic",
+    "repoOwner": "ros",
+    "sourceBranch": "ros2",
+    "targetBranchChoices": [
+        "ros2-rolling",
+        "ros2-humble",
+        "ros2-jazzy",
+        "ros2-kilted"
+    ],
+    "targetPRLabels": [
+        "automerge"
+    ]
+}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,4 +17,10 @@ pull_request_rules:
     actions:
       close: 
         message: Please make all PRs against the `ros2` branch. They will be backported if possible.
-      
+  - name: Automatic merge
+    description: Merge when PR passes all branch protection and has label automerge
+    conditions:
+      # Branch protections are automatically injected
+      - label = automerge
+    actions:
+      merge:


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-jazzy`:
 - [Automerge (#480)](https://github.com/ros/diagnostics/pull/480)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)