### PR TITLE
[ros2-kilted] Automerge (#480)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,14 @@
+{
+    "repoName": "diagnostic",
+    "repoOwner": "ros",
+    "sourceBranch": "ros2",
+    "targetBranchChoices": [
+        "ros2-rolling",
+        "ros2-humble",
+        "ros2-jazzy",
+        "ros2-kilted"
+    ],
+    "targetPRLabels": [
+        "automerge"
+    ]
+}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,3 +7,20 @@ pull_request_rules:
       label:
         add:
           - ros2
+  - name: no PRs against distro-specific branches
+    description: PRs against branches like ros-humble are closed automatically. Unless they are a backport.
+    conditions:
+      - and:
+        - base ~= ^ros2-[a-z]+$
+        - not:
+            head ~= ^backport\/.+$
+    actions:
+      close: 
+        message: Please make all PRs against the `ros2` branch. They will be backported if possible.
+  - name: Automatic merge
+    description: Merge when PR passes all branch protection and has label automerge
+    conditions:
+      # Branch protections are automatically injected
+      - label = automerge
+    actions:
+      merge:


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-kilted`:
 - [Automerge (#480)](https://github.com/ros/diagnostics/pull/480)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)