### PR TITLE
[ros2-humble] Listing all checks for automerge (#484)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,9 +1,8 @@
 {
-    "repoName": "diagnostic",
+    "repoName": "diagnostics",
     "repoOwner": "ros",
     "sourceBranch": "ros2",
     "targetBranchChoices": [
-        "ros2-rolling",
         "ros2-humble",
         "ros2-jazzy",
         "ros2-kilted"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -20,7 +20,19 @@ pull_request_rules:
   - name: Automatic merge
     description: Merge when PR passes all branch protection and has label automerge
     conditions:
-      # Branch protections are automatically injected
       - label = automerge
+      # we have to list all checks, apparently
+      - check-success = Check licenses
+      - check-success = Lint cppcheck
+      - check-success = Lint cpplint
+      - check-success = Lint flake8
+      - check-success = Lint uncurstify
+      - check-success = Lint xmllint
+      - check-success = diagnostic_aggregator on rolling
+      - check-success = diagnostic_common_diagnostics on rolling
+      - check-success = diagnostic_remote_logging on rolling
+      # - check-success = diagnostic_topic_monitor on rolling
+      - check-success = diagnostic_updater on rolling
+      - check-success = self_test on rolling
     actions:
       merge:


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-humble`:
 - [Listing all checks for automerge (#484)](https://github.com/ros/diagnostics/pull/484)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)