### PR TITLE
[ros2-humble] Checks for all distros (#488)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -28,11 +28,11 @@ pull_request_rules:
       - check-success = Lint flake8
       - check-success = Lint uncurstify
       - check-success = Lint xmllint
-      - check-success = diagnostic_aggregator on rolling
-      - check-success = diagnostic_common_diagnostics on rolling
-      - check-success = diagnostic_remote_logging on rolling
-      # - check-success = diagnostic_topic_monitor on rolling
-      - check-success = diagnostic_updater on rolling
-      - check-success = self_test on rolling
+      - check-success ~= diagnostic_aggregator on [a-z]+
+      - check-success ~= diagnostic_common_diagnostics on [a-z]+
+      - check-success ~= diagnostic_remote_logging on [a-z]+
+      # - check-success ~= diagnostic_topic_monitor on [a-z]+
+      - check-success ~= diagnostic_updater on [a-z]+
+      - check-success ~= self_test on [a-z]+
     actions:
       merge:


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-humble`:
 - [Checks for all distros (#488)](https://github.com/ros/diagnostics/pull/488)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)