### PR TITLE
[ros2-kilted] fix: replace deprecated MessageUniquePtr  (#400)

### DIFF
--- a/diagnostic_updater/include/diagnostic_updater/publisher.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/publisher.hpp
@@ -242,7 +242,9 @@ public:
    * The timestamp to be used by the TimeStampStatus class will be
    * extracted from message.header.stamp.
    */
-  virtual void publish(typename PublisherT::MessageUniquePtr message)
+  virtual void publish(
+    std::unique_ptr<typename PublisherT::ROSMessageType,
+    typename PublisherT::ROSMessageTypeDeleter> message)
   {
     tick(message->header.stamp);
     publisher_->publish(std::move(message));


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-kilted`:
 - [fix: replace deprecated MessageUniquePtr  (#400)](https://github.com/ros/diagnostics/pull/400)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)