### PR TITLE
[ros2-kilted] fix: Missing link to libcurl (#505)

### DIFF
--- a/diagnostic_remote_logging/CMakeLists.txt
+++ b/diagnostic_remote_logging/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(influx_component PUBLIC
     ${diagnostic_msgs_TARGETS}
     rclcpp::rclcpp
     rclcpp_components::component
+    CURL::libcurl
 )
 
 ament_export_dependencies(influx_component ${dependencies})


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-kilted`:
 - [fix: Missing link to libcurl (#505)](https://github.com/ros/diagnostics/pull/505)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)