### PR TITLE
Fix diagnostics_updater immediately throwing exception on windows

### DIFF
--- a/diagnostic_remote_logging/CMakeLists.txt
+++ b/diagnostic_remote_logging/CMakeLists.txt
@@ -9,6 +9,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+add_definitions(-DNOMINMAX)
 set(dependencies
     ament_cmake
     rclcpp

--- a/diagnostic_updater/CMakeLists.txt
+++ b/diagnostic_updater/CMakeLists.txt
@@ -53,6 +53,10 @@ ament_target_dependencies(
 )
 target_link_libraries(example ${PROJECT_NAME})
 
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE "DIAGNOSTIC_UPDATER_BUILDING_LIBRARY")
+
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   set(ament_cmake_copyright_FOUND TRUE)

--- a/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -47,6 +47,7 @@
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 
 #include "diagnostic_updater/diagnostic_status_wrapper.hpp"
+#include "diagnostic_updater/visibility_control.hpp"
 
 #include "rcl/time.h"
 
@@ -353,7 +354,7 @@ protected:
  * determined by the "~/diagnostic_updater.period" ros2 parameter.
  * The force_update function can always be triggered async to the period interval.
  */
-class Updater : public DiagnosticTaskVector
+class DIAGNOSTIC_UPDATER_PUBLIC Updater : public DiagnosticTaskVector
 {
 public:
   bool verbose_;

--- a/diagnostic_updater/include/diagnostic_updater/visibility_control.hpp
+++ b/diagnostic_updater/include/diagnostic_updater/visibility_control.hpp
@@ -1,0 +1,70 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef DIAGNOSTIC_UPDATER__VISIBILITY_CONTROL_HPP_
+#define DIAGNOSTIC_UPDATER__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define DIAGNOSTIC_UPDATER_EXPORT __attribute__ ((dllexport))
+    #define DIAGNOSTIC_UPDATER_IMPORT __attribute__ ((dllimport))
+  #else
+    #define DIAGNOSTIC_UPDATER_EXPORT __declspec(dllexport)
+    #define DIAGNOSTIC_UPDATER_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef DIAGNOSTIC_UPDATER_BUILDING_LIBRARY
+    #define DIAGNOSTIC_UPDATER_PUBLIC DIAGNOSTIC_UPDATER_EXPORT
+  #else
+    #define DIAGNOSTIC_UPDATER_PUBLIC DIAGNOSTIC_UPDATER_IMPORT
+  #endif
+  #define DIAGNOSTIC_UPDATER_PUBLIC_TYPE DIAGNOSTIC_UPDATER_PUBLIC
+  #define DIAGNOSTIC_UPDATER_LOCAL
+#else
+  #define DIAGNOSTIC_UPDATER_EXPORT __attribute__ ((visibility("default")))
+  #define DIAGNOSTIC_UPDATER_IMPORT
+  #if __GNUC__ >= 4
+    #define DIAGNOSTIC_UPDATER_PUBLIC __attribute__ ((visibility("default")))
+    #define DIAGNOSTIC_UPDATER_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define DIAGNOSTIC_UPDATER_PUBLIC
+    #define DIAGNOSTIC_UPDATER_LOCAL
+  #endif
+  #define DIAGNOSTIC_UPDATER_PUBLIC_TYPE
+#endif
+
+#endif  // DIAGNOSTIC_UPDATER__VISIBILITY_CONTROL_HPP_


### PR DESCRIPTION
Currently, any node using diagnostics updater immediately throws an exception for invalid access calling the virtual methods in Updater.



See documentation of the issue here
https://github.com/RoboStack/ros-jazzy/issues/81



