### PR TITLE
[ros2-jazzy] Fixing "AttributeError: 'RcutilsLogger' object has no attribute 'warn'" (#521)

### DIFF
--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/sensors_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/sensors_monitor.py
@@ -170,7 +170,7 @@ def parse_sensors_output(node: Node, output):
             try:
                 s = parse_sensor_line(line)
             except Exception as exc:
-                node.get_logger().warn(
+                node.get_logger().warning(
                     'Unable to parse line "%s", due to %s', line, exc
                 )
             if s is not None:

--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -288,13 +288,13 @@ class Updater(DiagnosticTaskVector):
                     warn_nohwid = False
 
                 if self.verbose and status.level != b'\x00':
-                    self.node.get_logger().warn(
+                    self.node.get_logger().warning(
                         'Non-zero diagnostic status. Name: %s, status\
                         %s: %s' % (status.name, str(status.level),
                                    status.message))
 
         if warn_nohwid and not self.warn_nohwid_done:
-            self.node.get_logger().warn(
+            self.node.get_logger().warning(
                 'diagnostic_updater: No HW_ID was set. This is probably\
                 a bug. Please report it. For devices that do not have a\
                 HW_ID, set this value to none. This warning only occurs\


### PR DESCRIPTION
# Backport

This will backport the following commits from `ros2` to `ros2-jazzy`:
 - [Fixing &quot;AttributeError: &#x27;RcutilsLogger&#x27; object has no attribute &#x27;warn&#x27;&quot; (#521)](https://github.com/ros/diagnostics/pull/521)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)