### PR TITLE
Fix windows build of diagnostic_remote_logging

### DIFF
--- a/diagnostic_common_diagnostics/diagnostic_common_diagnostics/sensors_monitor.py
+++ b/diagnostic_common_diagnostics/diagnostic_common_diagnostics/sensors_monitor.py
@@ -170,7 +170,7 @@ def parse_sensors_output(node: Node, output):
             try:
                 s = parse_sensor_line(line)
             except Exception as exc:
-                node.get_logger().warn(
+                node.get_logger().warning(
                     'Unable to parse line "%s", due to %s', line, exc
                 )
             if s is not None:

--- a/diagnostic_remote_logging/CMakeLists.txt
+++ b/diagnostic_remote_logging/CMakeLists.txt
@@ -9,6 +9,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if(WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 set(dependencies
     ament_cmake
     rclcpp

--- a/diagnostic_remote_logging/include/diagnostic_remote_logging/influxdb.hpp
+++ b/diagnostic_remote_logging/include/diagnostic_remote_logging/influxdb.hpp
@@ -39,6 +39,10 @@
 #ifndef DIAGNOSTIC_REMOTE_LOGGING__INFLUXDB_HPP_
 #define DIAGNOSTIC_REMOTE_LOGGING__INFLUXDB_HPP_
 
+#if defined(_WIN32)
+#define NOMINMAX
+#endif
+
 #include <curl/curl.h>
 #include <string>
 

--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -288,13 +288,13 @@ class Updater(DiagnosticTaskVector):
                     warn_nohwid = False
 
                 if self.verbose and status.level != b'\x00':
-                    self.node.get_logger().warn(
+                    self.node.get_logger().warning(
                         'Non-zero diagnostic status. Name: %s, status\
                         %s: %s' % (status.name, str(status.level),
                                    status.message))
 
         if warn_nohwid and not self.warn_nohwid_done:
-            self.node.get_logger().warn(
+            self.node.get_logger().warning(
                 'diagnostic_updater: No HW_ID was set. This is probably\
                 a bug. Please report it. For devices that do not have a\
                 HW_ID, set this value to none. This warning only occurs\


### PR DESCRIPTION
While working on a windows workflow for ros-controls, I encountered strange build errors from rclcpp. But it seems that the easier fix is to add `NOMINMAX` before including curl https://github.com/ros2/rclcpp/issues/2947#issuecomment-3339666233

Additionally, `unit_tests` did not build because no symbols were exported. There is no visibility control in the diagnostic_remote_logging, so I simply added `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`.

