### PR TITLE
Fixing the determination of ros distro from branch name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,14 +26,14 @@ jobs:
           fi
           echo "> Branch name is: ${branch_name}"
 
-          if [[ "${branch_name}" == *"ros2"* ]]; then
-            distro="rolling"
-          elif [[ "${branch_name}" == *"ros2-humble"* ]]; then
+          if [[ "${branch_name}" == *"ros2-humble"* ]]; then
             distro="humble"
           elif [[ "${branch_name}" == *"ros2-jazzy"* ]]; then
             distro="jazzy"
           elif [[ "${branch_name}" == *"ros2-kilted"* ]]; then
             distro="kilted"
+          elif [[ "${branch_name}" == *"ros2"* ]]; then
+            distro="rolling"
           else
             echo "! Unknown branch for determining ROS distro: ${GITHUB_REF##*/}"
             exit 1


### PR DESCRIPTION
Rolling must be last, because it matches the others, too.