### PR TITLE
Undefine ERROR macro when build on Windows

### DIFF
--- a/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/generic_analyzer_base.hpp
@@ -56,6 +56,10 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#ifdef ERROR
+#undef ERROR  //DiagnosticStatus::ERROR conflicts with Windows.h ERROR definition
+#endif
+
 namespace diagnostic_aggregator
 {
 /*!

--- a/diagnostic_aggregator/include/diagnostic_aggregator/other_analyzer.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/other_analyzer.hpp
@@ -48,6 +48,10 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 namespace diagnostic_aggregator
 {
 /*

--- a/diagnostic_aggregator/include/diagnostic_aggregator/status_item.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/status_item.hpp
@@ -51,6 +51,10 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 namespace diagnostic_aggregator
 {
 /*!

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -44,6 +44,10 @@
 #include <string>
 #include <vector>
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 namespace diagnostic_aggregator
 {
 using std::placeholders::_1;

--- a/diagnostic_aggregator/src/analyzer_group.cpp
+++ b/diagnostic_aggregator/src/analyzer_group.cpp
@@ -44,6 +44,10 @@
 #include <vector>
 #include <regex>
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 PLUGINLIB_EXPORT_CLASS(diagnostic_aggregator::AnalyzerGroup, diagnostic_aggregator::Analyzer)
 
 namespace diagnostic_aggregator

--- a/diagnostic_updater/src/example.cpp
+++ b/diagnostic_updater/src/example.cpp
@@ -38,6 +38,10 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 using namespace std::chrono_literals;
 
 double time_to_launch;

--- a/diagnostic_updater/test/diagnostic_status_wrapper_test.cpp
+++ b/diagnostic_updater/test/diagnostic_status_wrapper_test.cpp
@@ -37,6 +37,10 @@
 #include "diagnostic_updater/diagnostic_status_wrapper.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 TEST(DiagnosticStatusWrapper, testDiagnosticStatusWrapperDefaultConstructor) {
   // A default constructed DiagnosticStatusWrapper should be empty.
   diagnostic_updater::DiagnosticStatusWrapper dsw;

--- a/diagnostic_updater/test/diagnostic_updater_test.cpp
+++ b/diagnostic_updater/test/diagnostic_updater_test.cpp
@@ -46,6 +46,10 @@
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 using namespace std::chrono_literals;
 
 class TestClass

--- a/self_test/example/selftest_example.cpp
+++ b/self_test/example/selftest_example.cpp
@@ -36,6 +36,10 @@
 
 #include "self_test/test_runner.hpp"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 class MyNode : public rclcpp::Node
 {
 private:

--- a/self_test/test/selftest_node.hpp
+++ b/self_test/test/selftest_node.hpp
@@ -35,6 +35,10 @@
 
 #include "self_test/test_runner.hpp"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 /*
  *\author Kevin Watts
  *\brief Returns nominal self-test values


### PR DESCRIPTION
Undefine ERROR macro to build on Windows
