### PR TITLE
Fix expected matcher never populating expected_ in GenericAnalyzer

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -89,7 +89,8 @@ if(BUILD_TESTING)
     "primitive_analyzers"
     "all_analyzers"
     "analyzer_group"
-    "empty_root_path")
+    "empty_root_path"
+    "expected_only_analyzer")
 
   foreach(test_name ${create_analyzers_tests})
     file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/${test_name}.yaml" PARAMETER_FILE)

--- a/diagnostic_aggregator/src/generic_analyzer.cpp
+++ b/diagnostic_aggregator/src/generic_analyzer.cpp
@@ -113,7 +113,8 @@ bool GenericAnalyzer::init(
       RCLCPP_DEBUG(
         rclcpp::get_logger("GenericAnalyzer"), "GenericAnalyzer '%s' found expected: %s",
         nice_name_.c_str(), pvalue.value_to_string().c_str());
-      for (auto exp : pvalue.as_string_array()) {
+      expected_ = pvalue.as_string_array();
+      for (const auto & exp : expected_) {
         auto item = std::make_shared<StatusItem>(exp);
         this->addItem(exp, item);
       }

--- a/diagnostic_aggregator/test/expected_only_analyzer.yaml
+++ b/diagnostic_aggregator/test/expected_only_analyzer.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    log_level: debug
+    # Regression test for the `expected` matcher: an analyzer whose ONLY matcher
+    # is `expected` must still initialise. Prior to the fix this failed because
+    # the `expected` parameter populated the base-class items_ map but never the
+    # expected_ vector that the init guard checks, so the analyzer was dropped.
+    expected_only:
+      type: 'diagnostic_aggregator/GenericAnalyzer'
+      path: ExpectedOnly
+      expected: [ 'some/expected/status' ]

--- a/diagnostic_aggregator/test/expected_output/create_expected_only_analyzer.txt
+++ b/diagnostic_aggregator/test/expected_output/create_expected_only_analyzer.txt
@@ -1,0 +1,2 @@
+diagnostic_aggregator/GenericAnalyzer 'ExpectedOnly'
+/ExpectedOnly


### PR DESCRIPTION
Fixes #656

## Summary

`GenericAnalyzer`'s `expected` matcher is currently non-functional: the branch that parses the `expected` parameter only pre-seeds the base-class `items_` map (via `addItem()`) and never populates the `expected_` vector.

`expected_` is what the code actually relies on:

- **init guard** — `startswith_.size() == 0 && name_.size() == 0 && contains_.size() == 0 && expected_.size() == 0 && regex_.size() == 0` decides "was not initialized with any way of checking diagnostics";
- **`match()`** — iterates `expected_` (`name == expected_[i]`);
- **`report()`** — iterates `expected_` to detect missing expected items.

Because `expected_` is never written, an analyzer whose **only** matcher is `expected`:

1. fails to initialise (`GenericAnalyzer '<x>' was not initialized with any way of checking diagnostics`), which leaves its `AnalyzerGroup` empty and produces `Group '<x>' doesn't contain any analyzers, can't match`; and
2. would not match anything even when combined with another matcher, since `match()` reads the empty `expected_`.

This is a regression from the ROS 1 implementation, where the `expected` branch populated the vector via `getParamVals(expected, expected_)` before creating the pre-seeded items ([`noetic-devel` generic_analyzer.cpp](https://github.com/ros/diagnostics/blob/noetic-devel/diagnostic_aggregator/src/generic_analyzer.cpp)).

## Fix

Populate `expected_` from the parameter's string array alongside the existing `addItem()` loop:

```cpp
} else if (pname.compare("expected") == 0) {
  ...
  expected_ = pvalue.as_string_array();
  for (const auto & exp : expected_) {
    auto item = std::make_shared<StatusItem>(exp);
    this->addItem(exp, item);
  }
}
```

## Reproduction

Minimal analyzer config (`aggregator_node --ros-args --params-file expected.yaml`):

```yaml
/**:
  ros__parameters:
    path: Test
    loctest:
      type: diagnostic_aggregator/GenericAnalyzer
      path: LocTest
      expected: ['some/expected/status_name']
      timeout: 5.0
```

Before this change the node logs `GenericAnalyzer 'LocTest' was not initialized with any way of checking diagnostics` and `Group 'Test' doesn't contain any analyzers`. Swapping `expected` for `startswith`/`contains`/`regex` works, confirming the issue is specific to `expected`.

Verified against the installed Jazzy build (`diagnostic_aggregator` 4.2.7); the same code is present on `ros2` (rolling).

## Testing

Adds a create-analyzers launch test (`test/expected_only_analyzer.yaml` + `test/expected_output/create_expected_only_analyzer.txt`, wired into `create_analyzers_tests`) with an analyzer whose only matcher is `expected`. It asserts the success-only `Initialized analyzer ... with path '/ExpectedOnly'` log line, so it times out ("was not initialized with any way of checking diagnostics") without the fix and passes with it.

Verified locally on Jazzy:
- **Without the fix** (released 4.2.7 plugin): the new test fails (assertWaitFor timeout).
- **With the fix**: the new test passes.

## Notes

Draft: opening early for maintainer feedback. If preferred, the fixture could also be extended to an `output_`/behavioural test that publishes a matching status and checks aggregation.