### PR TITLE
Define WIN32_LEAN_AND_MEAN for remote logging

### DIFF
--- a/diagnostic_remote_logging/include/diagnostic_remote_logging/influxdb_connector.hpp
+++ b/diagnostic_remote_logging/include/diagnostic_remote_logging/influxdb_connector.hpp
@@ -41,6 +41,7 @@
 
 #if defined(_WIN32)
 #define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #endif
 
 #include <curl/curl.h>


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-diagnostic-remote-logging.win.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: diagnostic_remote_logging includes curl headers that can pull in Windows platform headers on MSVC. Defining WIN32_LEAN_AND_MEAN alongside NOMINMAX reduces Windows header surface and avoids common macro/type conflicts while preserving the existing non-Windows behavior.