### PR TITLE
Set hardware ID on startup and broadcast diagnostics

### DIFF
--- a/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
+++ b/diagnostic_updater/diagnostic_updater/_diagnostic_updater.py
@@ -334,6 +334,7 @@ class Updater(DiagnosticTaskVector):
         for task in self.tasks:
             status = DiagnosticStatusWrapper()
             status.name = task.name
+            status.hardware_id = self.hwid
             status.summary(lvl, msg)
             status_vec.append(status)
 
@@ -383,5 +384,6 @@ class Updater(DiagnosticTaskVector):
 
         stat = DiagnosticStatusWrapper()
         stat.name = task.name
+        stat.hardware_id = self.hwid
         stat.summary(self.__starting_up_status, 'Node starting up')
         self.publish(stat)

--- a/diagnostic_updater/src/diagnostic_updater.cpp
+++ b/diagnostic_updater/src/diagnostic_updater.cpp
@@ -95,6 +95,7 @@ void Updater::broadcast(unsigned char lvl, const std::string msg)
     diagnostic_updater::DiagnosticStatusWrapper status;
 
     status.name = iter->getName();
+    status.hardware_id = hwid_;
     status.summary(lvl, msg);
 
     status_vec.push_back(status);
@@ -195,6 +196,7 @@ void Updater::addedTaskCallback(DiagnosticTaskInternal & task)
 {
   DiagnosticStatusWrapper stat;
   stat.name = task.getName();
+  stat.hardware_id = hwid_;
   stat.summary(starting_up_status_, "Node starting up");
   publish(stat);
 }

--- a/diagnostic_updater/test/diagnostic_updater_test.cpp
+++ b/diagnostic_updater/test/diagnostic_updater_test.cpp
@@ -35,6 +35,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <future>
 #include <memory>
 #include <thread>
 
@@ -167,6 +168,45 @@ TEST(DiagnosticUpdater, testCustomContext) {
   updater.add(save_if_called);
   updater.force_update();
   ASSERT_TRUE(save_if_called.has_been_called());
+  context->shutdown("End test");
+}
+
+TEST(DiagnosticUpdater, testHardwareIDOnStartupAndBroadcast) {
+  auto context = std::make_shared<rclcpp::Context>();
+  context->init(0, nullptr, rclcpp::InitOptions());
+  auto node = std::make_shared<rclcpp::Node>(
+    "test_hardware_id", rclcpp::NodeOptions().context(context).use_intra_process_comms(true));
+  diagnostic_updater::Updater updater(node, 3600.0);
+  updater.setHardwareID("Device-27-46");
+
+  using DiagnosticArray = diagnostic_msgs::msg::DiagnosticArray;
+  std::promise<DiagnosticArray::ConstSharedPtr> received;
+  auto subscriber = node->create_subscription<DiagnosticArray>(
+    "/diagnostics", 10,
+    [&received](DiagnosticArray::ConstSharedPtr msg) {received.set_value(msg);});
+  rclcpp::ExecutorOptions options;
+  options.context = context;
+  rclcpp::executors::SingleThreadedExecutor executor(options);
+  executor.add_node(node);
+
+  auto future = received.get_future();
+  classFunction task;
+  updater.add(task);
+  ASSERT_EQ(rclcpp::FutureReturnCode::SUCCESS, executor.spin_until_future_complete(future, 2s));
+  auto msg = future.get();
+  ASSERT_EQ(1u, msg->status.size());
+  EXPECT_EQ("Device-27-46", msg->status[0].hardware_id);
+  EXPECT_EQ("Node starting up", msg->status[0].message);
+
+  received = std::promise<DiagnosticArray::ConstSharedPtr>();
+  future = received.get_future();
+  updater.broadcast(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Shutting down");
+  ASSERT_EQ(rclcpp::FutureReturnCode::SUCCESS, executor.spin_until_future_complete(future, 2s));
+  msg = future.get();
+  ASSERT_EQ(1u, msg->status.size());
+  EXPECT_EQ("Device-27-46", msg->status[0].hardware_id);
+  EXPECT_EQ("Shutting down", msg->status[0].message);
+  EXPECT_EQ(diagnostic_msgs::msg::DiagnosticStatus::WARN, msg->status[0].level);
   context->shutdown("End test");
 }
 

--- a/diagnostic_updater/test/diagnostic_updater_test.py
+++ b/diagnostic_updater/test/diagnostic_updater_test.py
@@ -7,6 +7,7 @@ import pathlib
 import sys
 import time
 import unittest
+from unittest.mock import patch
 
 from diagnostic_msgs.msg import DiagnosticStatus
 from diagnostic_updater import DiagnosticStatusWrapper
@@ -47,6 +48,29 @@ class TestClass:
 
 
 class TestDiagnosticStatusWrapper(unittest.TestCase):
+
+    def testHardwareIDOnStartupAndBroadcast(self):
+        context = rclpy.context.Context()
+        rclpy.init(context=context)
+        self.addCleanup(context.shutdown)
+        node = rclpy.create_node('test_hardware_id', context=context)
+        self.addCleanup(node.destroy_node)
+        updater = Updater(node)
+        updater.setHardwareID('Device-27-46')
+
+        with patch.object(updater.publisher, 'publish') as publish:
+            updater.add(ClassFunction())
+            msg = publish.call_args.args[0]
+            self.assertEqual(len(msg.status), 1)
+            self.assertEqual(msg.status[0].hardware_id, 'Device-27-46')
+            self.assertEqual(msg.status[0].message, 'Node starting up')
+
+            updater.broadcast(DiagnosticStatus.WARN, 'Shutting down')
+            msg = publish.call_args.args[0]
+            self.assertEqual(len(msg.status), 1)
+            self.assertEqual(msg.status[0].hardware_id, 'Device-27-46')
+            self.assertEqual(msg.status[0].message, 'Shutting down')
+            self.assertEqual(msg.status[0].level, DiagnosticStatus.WARN)
 
     def testDiagnosticUpdater(self):
         rclpy.init()


### PR DESCRIPTION
Fixes #666.

Set the hardware ID on startup and broadcast statuses in both the C++ and Python updaters, as the regular update path already does.

Adds regression tests for both paths. Tested on Rolling with colcon, flake8 and the Python updater unittest suite.
